### PR TITLE
Support multiple network interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "homebridge-midea",
-  "version": "1.0.0",
+  "name": "homebridge-midea-platform",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "homebridge-midea",
-      "version": "1.0.0",
+      "name": "homebridge-midea-platform",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.5.0",
         "fast-xml-parser": "^4.2.7",
-        "luxon": "^3.4.2"
+        "luxon": "^3.4.2",
+        "netmask": "^2.0.2"
       },
       "devDependencies": {
         "@types/luxon": "^3.3.1",
@@ -20,7 +21,7 @@
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.45.0",
         "homebridge": "^1.6.0",
-        "nodemon": "^2.0.22",
+        "nodemon": "^3.0.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
@@ -2253,6 +2254,14 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-persist": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.11.tgz",
@@ -2264,9 +2273,9 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
+      "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -2274,8 +2283,8 @@
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.5"
@@ -2284,7 +2293,7 @@
         "nodemon": "bin/nodemon.js"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
@@ -2307,15 +2316,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
@@ -2762,24 +2762,15 @@
       }
     },
     "node_modules/simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dev": true,
       "dependencies": {
-        "semver": "~7.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=10"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "axios": "^1.5.0",
     "fast-xml-parser": "^4.2.7",
-    "luxon": "^3.4.2"
+    "luxon": "^3.4.2",
+    "netmask": "^2.0.2"
   },
   "devDependencies": {
     "@types/luxon": "^3.3.1",
@@ -37,7 +38,7 @@
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.45.0",
     "homebridge": "^1.6.0",
-    "nodemon": "^2.0.22",
+    "nodemon": "^3.0.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"

--- a/src/core/MideaDiscover.ts
+++ b/src/core/MideaDiscover.ts
@@ -5,6 +5,10 @@ import { XMLParser } from 'fast-xml-parser';
 import EventEmitter from 'events';
 import { LocalSecurity } from './MideaSecurity';
 
+// To access network interface detail...
+import os from 'os';
+const Netmask = require('netmask').Netmask;
+
 export default class Discover extends EventEmitter {
 
   private readonly IPV4_BROADCAST = '255.255.255.255';
@@ -34,20 +38,23 @@ export default class Discover extends EventEmitter {
     });
 
     this.socket.on('message', async (msg, rinfo) => {
-      this.ips.push(rinfo.address);
+      if (!this.ips.includes(rinfo.address)) {
+        // Only add device if it has not already been added.
+        this.ips.push(rinfo.address);
 
-      const device_version = this.getDeviceVersion(msg);
-      const device_info = await this.getDeviceInfo(rinfo.address, device_version, msg);
-      this.logger.debug(`Discovered device at ${rinfo.address} (${JSON.stringify(device_info)}).`);
+        const device_version = this.getDeviceVersion(msg);
+        const device_info = await this.getDeviceInfo(rinfo.address, device_version, msg);
+        this.logger.debug(`Discovered device at ${rinfo.address} (${JSON.stringify(device_info)}).`);
 
-      this.emit('device', device_info);
+        this.emit('device', device_info);
+      }
     });
   }
 
   public discoverDeviceByIP(ip: string, retries = 3) {
     let tries = 0;
     const interval = setInterval(() => {
-      if (this.ips.includes(ip) || tries++ > retries) {
+      if (this.ips.includes(ip) || tries++ >= retries) {
         clearInterval(interval);
         return;
       }
@@ -62,15 +69,56 @@ export default class Discover extends EventEmitter {
     }, 3000);
   }
 
-  public startDiscover() {
-
-    for (const port of [6445, 20086]) {
-      this.socket.send(Buffer.from(DISCOVERY_MESSAGE), port, this.IPV4_BROADCAST, (err) => {
-        if (err) {
-          this.logger.error(`Error while sending message to ${this.IPV4_BROADCAST}:${port}: ${err}`);
+  /*********************************************************************
+   * ifBroadcastAddrs
+   * Broadcasts to 255.255.255.255 only gets sent out on the first network inteface. 
+   * This function finds all network interfaces and returns the broadcast address
+   * for each in an array, e.g. ['192.168.1.255', '192.168.100.255'].  If there are
+   * multiple interfaces this will cause broadcast to be sent out on each interface
+   * so all appliances are properly discovered.
+   */
+  private ifBroadcastAddrs(): string[] {
+    let list: string[] = [];
+    try {
+      const ifaces: Object = os.networkInterfaces();
+      for (let iface in ifaces) {
+        for (let i in ifaces[iface]) {
+          const f = ifaces[iface][i];
+          if (!f.internal && f.family === 'IPv4') {
+            // only IPv4 addresses excluding any loopback interface
+            list.push(new Netmask(f.cidr).broadcast);
+          }
         }
-      });
+      }
+    } catch (e) {
+      const msg = (e instanceof Error) ? e.stack : e;
+      this.logger.error(`Fatal error during plugin initialization:\n${msg}`);
     }
+    // this.logger.info(`Broadcast addresses: ${JSON.stringify(list)}`);
+    return (list);
+  }
+
+  public startDiscover(retries = 3) {
+    let tries = 0;
+    const broadcastAddrs = this.ifBroadcastAddrs();
+
+    const interval = setInterval(() => {
+      if (tries++ >= retries) {
+        clearInterval(interval);
+        return;
+      }
+      for (const ip of broadcastAddrs) {
+        this.logger.debug(`Sending discovery message to ${ip}, try ${tries}...`);
+        for (const port of [6445, 20086]) {
+          this.socket.send(Buffer.from(DISCOVERY_MESSAGE), port, ip, (err) => {
+            if (err) {
+              const msg = (err instanceof Error) ? err.stack : err;
+              this.logger.error(`Error while sending message to ${ip}:${port}:\n${msg}`);
+            }
+          });
+        }
+      }
+    }, 3000);
   }
 
   private getDeviceVersion(data: Buffer) {
@@ -90,7 +138,7 @@ export default class Discover extends EventEmitter {
     throw new Error('Unknown device version.');
   }
 
-  private async getDeviceInfo(ip: string, version: ProtocolVersion, data: Buffer) : Promise<DeviceInfo> {
+  private async getDeviceInfo(ip: string, version: ProtocolVersion, data: Buffer): Promise<DeviceInfo> {
     if (version === ProtocolVersion.V1) {
       // const root = this.xml_parser.parse(data.toString());
       // const device = root["body"]["device"]

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -33,6 +33,7 @@ export class MideaPlatform implements DynamicPlatformPlugin {
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
+    Error.stackTraceLimit = 100;
     this.log.debug('Finished initializing platform:', PLATFORM_NAME);
 
     this.cloud = CloudFactory.createCloud(this.config['user'], this.config['password'], log, this.config['registeredApp']);
@@ -45,8 +46,8 @@ export class MideaPlatform implements DynamicPlatformPlugin {
 
     this.discover.on('device', (device_info: DeviceInfo) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const configDev : DeviceConfig = this.config['devices'].find((dev: DeviceConfig) => dev.ip === device_info.ip);
-      device_info.name = configDev.name || device_info.name;
+      const configDev: DeviceConfig = this.config['devices'].find((dev: DeviceConfig) => dev.ip === device_info.ip);
+      device_info.name = configDev?.name || device_info.name;
       this.addDevice(device_info, configDev);
     });
 
@@ -60,16 +61,19 @@ export class MideaPlatform implements DynamicPlatformPlugin {
       this.cloud.login()
         .then(() => {
           this.log.info('Logged in to Midea Cloud.');
-          // this.discover.startDiscover();
+          this.discover.startDiscover();
           if (this.config['devices']) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             this.config['devices'].forEach((device: any) => {
-              this.discover.discoverDeviceByIP(device.ip);
+              if (device.ip) {
+                this.discover.discoverDeviceByIP(device.ip);
+              }
             });
           }
         })
         .catch((error) => {
-          this.log.error(`Error logging in to Midea Cloud: ${error}`);
+          const msg = (error instanceof Error) ? error.stack : error;
+          this.log.error(`Error logging in to Midea Cloud: ${msg}`);
         });
     });
   }
@@ -112,7 +116,7 @@ export class MideaPlatform implements DynamicPlatformPlugin {
           const endianess: Endianness = i === 0 ? 'little' : 'big';
           let token: Buffer | undefined, key: Buffer | undefined = undefined;
           try {
-            [ token, key ] = await this.cloud.getToken(device_info.id, endianess);
+            [token, key] = await this.cloud.getToken(device_info.id, endianess);
           } catch (e) {
             this.log.debug(`Getting token and key with ${endianess}-endian is not successful: ${e}`);
           }


### PR DESCRIPTION
I want to help with developing this plugin.  Specifically I want to add support for dehumidifier I bought.  I made a start by forking a different project and made significant updates to it (so it can work entirely on LAN and not need to connect to Midea cloud servers).  That work is here... [homebridge-midea-lan](https://github.com/dkerr64/homebridge-midea-lan).

But I much prefer how you are going about it (not having a dependency on the midea-beautiful-air python package for a start). So want to help improve your plugin with some of the things I learned.  First step is this... if you have multiple network interfaces then you cannot broadcast to 255.255.255.255, you need to broadcast to each subnet separately. This pull request does that.

Thanks!
