### PR TITLE
fix: error to warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea",
   "name": "homebridge-midea-platform",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -287,8 +287,9 @@ export default abstract class MideaDevice extends EventEmitter {
             }
           } catch (err) {
             error_cnt++;
+            // TODO: handle connection error
             // this.unsupported_protocol.push(cmd.constructor.name);
-            this.logger.error(
+            this.logger.warn(
               `[${this.name}] Does not supports the protocol ${cmd.constructor.name}, ignored, error: ${err}`,
             );
           }

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -432,10 +432,10 @@ export default abstract class MideaDevice extends EventEmitter {
    * and proceses each message as received.
    */
   private async run() {
-    this.logger.info(`Starting network listener for [${this.name}]`);
+    this.logger.info(`[${this.name}] Starting network listener.`);
     while (this.is_running) {
       while (this.promiseSocket.destroyed) {
-        this.logger.debug('Create new socket, reconnect');
+        this.logger.info(`[${this.name}] Create new socket, reconnect`);
         this.promiseSocket = new PromiseSocket(this.logger, this.verbose);
         await this.connect(true); // need to refresh_status on connect as we reset start time below.
         const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -489,12 +489,14 @@ export default abstract class MideaDevice extends EventEmitter {
           }
         } catch (e) {
           const msg = e instanceof Error ? e.stack : e;
-          this.logger.error(
-            `[${this.name} | run] Error reading from socket:\n${msg}`,
-          );
+          if (this.verbose) {
+            this.logger.warn(
+              `[${this.name} | run] Error reading from socket:\n${msg}`,
+            );
+          }
         }
       }
     }
-    this.logger.info(`Stopping network listener for [${this.name}]`);
+    this.logger.info(`[${this.name}] Stopping network listener.`);
   }
 }

--- a/src/core/MideaUtils.ts
+++ b/src/core/MideaUtils.ts
@@ -75,10 +75,6 @@ export function calculate(data: Buffer) {
   return crc;
 }
 
-function formattedDate() {
-  return new Date().toISOString().replace(/T/, ', ').replace(/\..+/, '');
-}
-
 /*********************************************************************
  * PromiseSocket
  * A very basic implementation of promise-wrapped Socket
@@ -98,9 +94,7 @@ export class PromiseSocket {
       // Log the error
       const msg = e instanceof Error ? e.stack : e;
       if (this.verbose) {
-        this.logger.warn(
-          `[${formattedDate()}] [homebridge-midea-platform] Socket error:\n${msg}`,
-        );
+        this.logger.warn(`Socket error:\n${msg}`);
       }
       // According to https://nodejs.org/api/net.html#event-error_1 the "close" event
       // will be called immediately following an "error" event.  So don't throw an error
@@ -110,9 +104,7 @@ export class PromiseSocket {
       this.destroy();
       if (this.verbose) {
         this.logger.warn(
-          `[${formattedDate()}] [homebridge-midea-platform] Socket closed ${
-            hadError ? 'with' : 'without'
-          } error`,
+          `Socket closed ${hadError ? 'with' : 'without'} error`,
         );
       }
     });

--- a/src/core/MideaUtils.ts
+++ b/src/core/MideaUtils.ts
@@ -98,7 +98,7 @@ export class PromiseSocket {
       // Log the error
       const msg = e instanceof Error ? e.stack : e;
       if (this.verbose) {
-        this.logger.error(
+        this.logger.warn(
           `[${formattedDate()}] [homebridge-midea-platform] Socket error:\n${msg}`,
         );
       }
@@ -108,12 +108,13 @@ export class PromiseSocket {
     });
     this.innerSok.on('close', async (hadError: boolean) => {
       this.destroy();
-      // eslint-disable-next-line no-console
-      console.info(
-        `[${formattedDate()}] [homebridge-midea-platform] Socket closed ${
-          hadError ? 'with' : 'without'
-        } error`,
-      );
+      if (this.verbose) {
+        this.logger.warn(
+          `[${formattedDate()}] [homebridge-midea-platform] Socket closed ${
+            hadError ? 'with' : 'without'
+          } error`,
+        );
+      }
     });
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -102,9 +102,6 @@ export class MideaPlatform implements DynamicPlatformPlugin {
     this.log.info(
       `Socket heartbeat interval set to ${this.config.heartbeatInterval} seconds`,
     );
-    this.log.info(
-      `Socket heartbeat interval set to ${this.config.heartbeatInterval} seconds`,
-    );
 
     this.cloud = CloudFactory.createCloud(
       this.config.user,
@@ -315,8 +312,8 @@ export class MideaPlatform implements DynamicPlatformPlugin {
   private async getNewCredentials(device: MideaDevice): Promise<boolean> {
     let connected = false;
     let i = 0;
-    let token: Buffer | undefined,
-      key: Buffer | undefined = undefined;
+    let token: Buffer | undefined = undefined;
+    let key: Buffer | undefined = undefined;
     // Need to make two passes to obtain token/key credentials as they may work or not
     // depending on byte order (little or big-endian).  Exit the loop as soon as one
     // works or having tried both.
@@ -340,6 +337,13 @@ export class MideaPlatform implements DynamicPlatformPlugin {
     // token / key pair to undefined.  Handle the error in the calling function.
     if (!connected) {
       device.setCredentials(undefined, undefined);
+    } else {
+      if (this.config.verbose) {
+        this.log.debug(
+          `[${device.name}] New token/key from cloud: ` +
+            `${token?.toString('hex')} / ${key?.toString('hex')}`,
+        );
+      }
     }
     return connected;
   }


### PR DESCRIPTION
I have replaced some error to warnings, as they are "handled" errors.

@dkerr64 I've also added a TODO when the unsupported protocols being handled. I've commented out the handling because in some cases the message was compatible with my device but there were a connection error while reading from the device with caused the command being marked as "unsupported".