### PR TITLE
Handle case where config is undefined (nothing in config.json yet)

### DIFF
--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -75,11 +75,11 @@ class UiServer extends HomebridgePluginUiServer {
     super();
     // Obtain the plugin configuration from homebridge config JSON file.
     const config = require(this.homebridgeConfigPath).platforms.find((obj) => obj.platform === 'midea-platform');
-    this.logger = new Logger(config.uiDebug ? config.uiDebug : false);
+    this.logger = new Logger(config?.uiDebug ? config.uiDebug : false);
     this.logger.info(`Custom UI created.`);
     this.logger.debug(`ENV:\n${JSON.stringify(process.env, null, 2)}`);
     this.security = new LocalSecurity();
-    this.promiseSocket = new PromiseSocket(this.logger, config.logRecoverableErrors ? config.logRecoverableErrors : false);
+    this.promiseSocket = new PromiseSocket(this.logger, config?.logRecoverableErrors ? config.logRecoverableErrors : false);
 
     this.onRequest('/login', async ({ username, password, registeredApp }) => {
       try {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea",
   "name": "homebridge-midea-platform",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Unfortunately I wasn't handling case where nothing exists in config.json yet.

Sorry for all the bugs that I am only finding when I try and install/use on a clean system.  Need to figure out how to test this scenario before publishing.