### PR TITLE
fix: handling of protocol version 2 devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Midea device status is retrieved over your Local Area Network (LAN) and credenti
 
 ## Device Discovery
 
-Credentials for each Midea device on your Local Area Network (LAN) must be retrieved from Midea cloud server, this is done through the Settings window in the Homebridge Config User Interface.  On opening the settings window, click on *Discover Devices* and enter the requested information.
+Midea devices uses different communication protocols. Protocol version 3 needs credentials for each device. Credentials for this Midea devices on your Local Area Network (LAN) must be retrieved from Midea cloud server, this is done through the Settings window in the Homebridge Config User Interface. On opening the settings window, click on *Discover Devices* and enter the requested information. You can also run the discovery without providing your login credentials, however in this case if a protocol version 3 device is found in your network, it cannot be added. If you have a protocol version 3 device, you must provide your login credentials.
 
-* **Registered app** *(required)*: Name of the Midea mobile app that you registered your userid and password with.  Defaults to *Midea SmartHome (MSmartHome)*, but you can also select *NetHome Plus* or *Meiju*.
-* **Username** *(required)*: Email address / userid that you use to login to the Midea cloud service.
-* **Password** *(required)*: Password for Midea cloud service
+* **Registered app**: Name of the Midea mobile app that you registered your userid and password with.  Defaults to *Midea SmartHome (MSmartHome)*, but you can also select *NetHome Plus* or *Meiju*.
+* **Username**: Email address / userid that you use to login to the Midea cloud service.
+* **Password**: Password for Midea cloud service
 
 On clicking *Discover All Devices* the plugin sends a message to the broadcast address for the subnet of each network interface attached to the Homebridge server.  Midea devices attached to the network will respond.  Network discovery is repeated multiple times (currently 4 times at interval of 2 seconds between each).  At the end of the process details of all devices discovered are listed in the Settings window.  From there, you can add new devices or update the *token/key* credentials for existing devices.  You can then edit details for each device (for example change the name).
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Midea device status is retrieved over your Local Area Network (LAN) and credenti
 
 ## Device Discovery
 
-Midea devices uses different communication protocols. Protocol version 3 needs credentials for each device. Credentials for this Midea devices on your Local Area Network (LAN) must be retrieved from Midea cloud server, this is done through the Settings window in the Homebridge Config User Interface. On opening the settings window, click on *Discover Devices* and enter the requested information. You can also run the discovery without providing your login credentials, however in this case if a protocol version 3 device is found in your network, it cannot be added. If you have a protocol version 3 device, you must provide your login credentials.
+Midea devices use different communication protocols. Protocol version 3 needs credentials for each device. Credentials for these Midea devices on your Local Area Network (LAN) must be retrieved from Midea cloud server, this is done through the Settings window in the Homebridge Config User Interface. On opening the settings window, click on *Discover Devices* and enter the requested information. You can run the discovery without providing your login credentials, however in this case if a protocol version 3 device is found in your network, it cannot be added. If you have a protocol version 3 device, you must provide your login credentials.
 
-* **Registered app**: Name of the Midea mobile app that you registered your userid and password with.  Defaults to *Midea SmartHome (MSmartHome)*, but you can also select *NetHome Plus* or *Meiju*.
-* **Username**: Email address / userid that you use to login to the Midea cloud service.
-* **Password**: Password for Midea cloud service
+* **Registered app** *(optional)*: Name of the Midea mobile app that you registered your userid and password with.  Defaults to *Midea SmartHome (MSmartHome)*, but you can also select *NetHome Plus* or *Meiju*.
+* **Username** *(optional)*: Email address / userid that you use to login to the Midea cloud service.
+* **Password** *(optional)*: Password for Midea cloud service.
+* **IP Addresses** *(optional)*: Comma- or space-separated list of device IP addresses.
 
 On clicking *Discover All Devices* the plugin sends a message to the broadcast address for the subnet of each network interface attached to the Homebridge server.  Midea devices attached to the network will respond.  Network discovery is repeated multiple times (currently 4 times at interval of 2 seconds between each).  At the end of the process details of all devices discovered are listed in the Settings window.  From there, you can add new devices or update the *token/key* credentials for existing devices.  You can then edit details for each device (for example change the name).
 
@@ -105,9 +106,9 @@ If you delete a device in the plugin settings window, or the Homebridge config.j
   * **name** *(optional)*: This replaces the name set by the Midea device and is displayed in the Homebridge accessories page. Entries in the log are prefixed with this name to assist in identifying the source of information being logged.
   * **id** *(required)*: ID to identify specific device.  This will be filled in by the device discovery process in the Settings window but uou can also find this from the Homebridge log during plugin initialization or in the Homebridge Config UI X by clicking on an accessory settings and copying the *Product Data* field.
   * **advanced_options** *(required)*: Object with settings specific for this device:
-    * **ip** *(optional)*: IP address of device on your local LAN. This is only required if the device is not on the same LAN subnet as your Homebridge server.
-    * **token** *(required)*: Device login token.
-    * **key** *(required)*: Device login key. Specifying a token/key pair will override any values previously cached by the plugin.
+    * **ip** *(optional)*: IP address of device on your local LAN. Required if the device is not on the same LAN subnet as your Homebridge server.
+    * **token** *(optional)*: Device login token. Required for protocol version 3 devices.
+    * **key** *(optional)*: Device login key. Specifying a token/key pair will override any values previously cached by the plugin. Required for protocol version 3 devices.
     * **verbose** *(optional)*: Override global setting for this one device.
     * **logRecoverableErrors** *(optional)*: Override global setting for this one device.
   * **<device_options>** *(optional)*: Object with name and options that are device type specific.  See *device notes* below.

--- a/config.schema.json
+++ b/config.schema.json
@@ -78,13 +78,11 @@
                 "token": {
                   "title": "Device login token",
                   "type": "string",
-                  "required": true,
                   "description": "Token of the device obtained from cloud. This shouldn't be changed if it was added by discovery."
                 },
                 "key": {
                   "title": "Device login key",
                   "type": "string",
-                  "required": true,
                   "description": "Key of the device obtained from cloud. This shouldn't be changed if it was added by discovery."
                 },
                 "verbose": {

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -25,10 +25,10 @@
     <div class="collapse" id="discoverDevices">
       <div class="card-body">
         <form>
-          <div class="mb-3 bg-info-subtle border-info-subtle p-3 rounded-2">
-            You can discover your devices without providing credentials, but for protocol version 3 devices you must
-            provide them.
-            After you discover you can see which devices are using protocol version 3.
+          <div class="mb-3">
+            You can discover your devices without providing credentials. However, if you see <i>No Credentials</i> in the
+            Add/Update column then you must provide login credentials so that a <i>token/key</i> pair can be retrieved
+            from Midea cloud servers, these are protocol version 3 devices.
           </div>
           <div class="mb-3">
             <label for="registeredApp" class="form-label">Registered app</label>
@@ -49,7 +49,7 @@
           <div class="mb-3">
             <label for="ip" class="form-label">IP Addresses (comma or space separated list for when devices are on
               another LAN subnet)</label>
-            <input type="text" class="form-control" id="ip" placeholder="IP addresses">
+            <input type="text" class="form-control" id="ip" placeholder="IP addresses (optional)">
           </div>
           <button class="btn btn-primary btn-login" type="submit" id="discoverBtn" style="border: 0;">
             Discover All Devices

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -63,6 +63,7 @@
                 <th scope="col">Type</th>
                 <th scope="col">Model</th>
                 <th scope="col">Id</th>
+                <th scope="col">Ver.</th>
                 <th scope="col">Token&nbsp;/&nbsp;Key</th>
                 <th scope="col">Local&nbsp;Ip</th>
                 <th scope="col">Add&nbsp;/&nbsp;Update</th>
@@ -229,6 +230,7 @@
           tr.insertCell().appendChild(document.createTextNode(device.displayName));
           tr.insertCell().appendChild(document.createTextNode(device.model));
           tr.insertCell().appendChild(document.createTextNode(device.id));
+          tr.insertCell().appendChild(document.createTextNode(device.version));
           if (device.version === 3) {
             tr.insertCell().appendChild(document.createTextNode(
               device.token ?

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -26,7 +26,8 @@
       <div class="card-body">
         <form>
           <div class="mb-3 bg-info-subtle border-info-subtle p-3 rounded-2">
-            You can discover your devices without providing credentials, but for protocol version 3 devices you must provide them.
+            You can discover your devices without providing credentials, but for protocol version 3 devices you must
+            provide them.
             After you discover you can see which devices are using protocol version 3.
           </div>
           <div class="mb-3">
@@ -173,10 +174,20 @@
 
       homebridge.showSpinner();
 
-    
+
       console.info(`Request login...`);
       // Login is only needed for protocol version 3 devices, so it's optional
-      await homebridge.request('/login', { username, password, registeredApp });
+      if (username && password && registeredApp) {
+        try {
+          console.info(`Request login...`);
+          await homebridge.request('/login', { username, password, registeredApp });
+        } catch (e) {
+          homebridge.toast.error(e.message);
+          homebridge.hideSpinner();
+          // Abort if we did not login successfully.
+          return;
+        }
+      }
 
       const table = document.getElementById('discoverTable').getElementsByTagName('tbody')[0];
       table.innerHTML = '';
@@ -226,13 +237,13 @@
           tr.insertCell().appendChild(document.createTextNode(device.version));
           if (device.version === 3) {
             tr.insertCell().appendChild(document.createTextNode(
-            device.token ?
-              device.token.slice(0, 6) + '...' + device.token.slice(-4) :
-              'token missing' + '\n' +
-                device.key ?
-                device.key.slice(0, 6) + '...' + device.key.slice(-4) :
-                'key missing'
-          ));
+              device.token ?
+                device.token.slice(0, 6) + '...' + device.token.slice(-4) :
+                'token missing' + '\n' +
+                  device.key ?
+                  device.key.slice(0, 6) + '...' + device.key.slice(-4) :
+                  'key missing'
+            ));
           } else {
             tr.insertCell().appendChild(document.createTextNode('not needed'));
           }
@@ -242,7 +253,7 @@
           if (device.displayName === 'Unknown') {
             addCell.appendChild(document.createTextNode('Not supported'));
           } else if (!validAuth) {
-            addCell.appendChild(document.createTextNode('Invalid credentials'));
+            addCell.appendChild(document.createTextNode('No credentials'));
           } else if (currentConfig.devices.find((d) => d.id === device.id)) {
             // We already have a record for this device, either with device ID, add button to update it.
             const button = document.createElement('button');

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -25,6 +25,10 @@
     <div class="collapse" id="discoverDevices">
       <div class="card-body">
         <form>
+          <div class="mb-3 bg-info-subtle border-info-subtle p-3 rounded-2">
+            You can discover your devices without providing credentials, but for protocol version 3 devices you must provide them.
+            After you discover you can see which devices are using protocol version 3.
+          </div>
           <div class="mb-3">
             <label for="registeredApp" class="form-label">Registered app</label>
             <select id="registeredApp" class="form-select">
@@ -58,6 +62,7 @@
                 <th scope="col">Type</th>
                 <th scope="col">Model</th>
                 <th scope="col">Id</th>
+                <th scope="col">Protocol Version</th>
                 <th scope="col">Token&nbsp;/&nbsp;Key</th>
                 <th scope="col">Local&nbsp;Ip</th>
                 <th scope="col">Add&nbsp;/&nbsp;Update</th>
@@ -166,22 +171,12 @@
       const registeredApp = document.getElementById('registeredApp').value;
       let ipAddrs = document.getElementById('ip').value ? document.getElementById('ip').value.split(/[\s,]+/) : [];
 
-      if (!username || !password || !registeredApp) {
-        homebridge.toast.error('Please enter username, password and registered app');
-        return;
-      }
-
       homebridge.showSpinner();
 
-      try {
-        console.info(`Request login...`);
-        await homebridge.request('/login', { username, password, registeredApp });
-      } catch (e) {
-        homebridge.toast.error(e.message);
-        homebridge.hideSpinner();
-        // Abort if we did not login successfully.
-        return;
-      }
+    
+      console.info(`Request login...`);
+      // Login is only needed for protocol version 3 devices, so it's optional
+      await homebridge.request('/login', { username, password, registeredApp });
 
       const table = document.getElementById('discoverTable').getElementsByTagName('tbody')[0];
       table.innerHTML = '';
@@ -218,7 +213,8 @@
       currentConfig.devices = currentConfig.devices || [];
       if (devices) {
         devices.forEach((device) => {
-          const validAuth = device.token && device.key;
+          // Token and key only needed for protocol version 3
+          const validAuth = (device.token && device.key) || device.version !== 3;
           const tr = table.insertRow();
           const td = tr.insertCell();
           td.appendChild(document.createTextNode(device.name));
@@ -227,7 +223,9 @@
           tr.insertCell().appendChild(document.createTextNode(device.displayName));
           tr.insertCell().appendChild(document.createTextNode(device.model));
           tr.insertCell().appendChild(document.createTextNode(device.id));
-          tr.insertCell().appendChild(document.createTextNode(
+          tr.insertCell().appendChild(document.createTextNode(device.version));
+          if (device.version === 3) {
+            tr.insertCell().appendChild(document.createTextNode(
             device.token ?
               device.token.slice(0, 6) + '...' + device.token.slice(-4) :
               'token missing' + '\n' +
@@ -235,6 +233,9 @@
                 device.key.slice(0, 6) + '...' + device.key.slice(-4) :
                 'key missing'
           ));
+          } else {
+            tr.insertCell().appendChild(document.createTextNode('not needed'));
+          }
           tr.insertCell().appendChild(document.createTextNode(device.ip));
 
           const addCell = tr.insertCell();

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -25,7 +25,7 @@
     <div class="collapse" id="discoverDevices">
       <div class="card-body">
         <form>
-          <div class="mb-3">
+          <div class="mb-3 bg-info-subtle border-info-subtle p-3 rounded-2">
             You can discover your devices without providing credentials. However, if you see <i>No Credentials</i> in the
             Add/Update column then you must provide login credentials so that a <i>token/key</i> pair can be retrieved
             from Midea cloud servers, these are protocol version 3 devices.

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -10,7 +10,7 @@
 const { HomebridgePluginUiServer, RequestError } = require('@homebridge/plugin-ui-utils');
 const Discover = require('../dist/core/MideaDiscover.js').default;
 const CloudFactory = require('../dist/core/MideaCloud.js').default;
-const { DeviceType, TCPMessageType } = require("../dist/core/MideaConstants.js");
+const { DeviceType, TCPMessageType, ProtocolVersion } = require("../dist/core/MideaConstants.js");
 const { LocalSecurity } = require("../dist/core/MideaSecurity.js");
 const { PromiseSocket } = require("../dist/core/MideaUtils.js");
 const { defaultConfig, defaultDeviceConfig } = require('../dist/platformUtils.js');
@@ -88,7 +88,6 @@ class UiServer extends HomebridgePluginUiServer {
       } catch (e) {
         const msg = e instanceof Error ? e.stack : e;
         this.logger.warn(`Login failed:\n${msg}`);
-        throw new RequestError('Login failed, check credentials.');
       }
     });
 
@@ -114,7 +113,12 @@ class UiServer extends HomebridgePluginUiServer {
       try {
         const devices = await this.blockingDiscover(ip);
         for (const device of devices) {
-          await this.getNewCredentials(device);
+          if (device.version === ProtocolVersion.V3 && this.cloud.loggedIn) {
+            await this.getNewCredentials(device);
+          } else {
+            device.token = '';
+            device.key = '';
+          }
         }
         this.logger.debug(`All devices:\n${JSON.stringify(devices, null, 2)}`);
         return devices

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/core/MideaCloud.ts
+++ b/src/core/MideaCloud.ts
@@ -30,7 +30,7 @@ abstract class CloudBase<T extends CloudSecurity> {
   protected key?: string;
 
   protected semaphore: Semaphore;
-  protected loggedIn = false;
+  public loggedIn = false;
 
   constructor(
     protected readonly account: string,
@@ -266,7 +266,9 @@ class UnProxiedCloudBase<T extends CloudSecurity> extends CloudBase<T> {
       if (response) {
         this.access_token = response['accessToken'];
         this.sessionId = response['sessionId'];
+        this.loggedIn = true;
       } else {
+        this.loggedIn = false;
         throw new Error('Failed to login.');
       }
     } catch (e) {


### PR DESCRIPTION
Because the v2 devices don't need token/key the login process of the discovery method is optional. After discovering the devices the user can see which devices using protocol version 3 and which are not. Protocol version 2 devices can be added without token/key.