### PR TITLE
Show discovery progress messages (toast popups)

### DIFF
--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -110,6 +110,19 @@
     configuration = await homebridge.request('/mergeToDefault', { config: configuration });
 
     /*********************************************************************
+     * showToast event listener
+     * Provides information from server-side to the end user.
+     */
+    homebridge.addEventListener('showToast', (event) => {
+      debugLog(`showToast Received: ${JSON.stringify(event.data)}`);
+      if (event.data.success) {
+        homebridge.toast.success(event.data.msg);
+      } else {
+        homebridge.toast.error(event.data.msg);
+      }
+    });
+
+    /*********************************************************************
      * filterOutDefaults
      * returns object for config.json that has default values removed
      */

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -231,12 +231,13 @@ class UiServer extends HomebridgePluginUiServer {
             break;
         }
         devices.push(device);
-        this.pushEvent('showToast', { success: true, msg: `Discovered ${device.name} at ${device.ip}`, device: device });
+        // too verbose to post every device as found...
+        // this.pushEvent('showToast', { success: true, msg: `Discovered ${device.name} at ${device.ip}`, device: device });
       });
 
-      discover.on('retry', (tries) => {
+      discover.on('retry', (nTry, nDevices) => {
         this.logger.info('Device discovery complete.');
-        this.pushEvent('showToast', { success: true, msg: `Continuing to search for devices...` });
+        this.pushEvent('showToast', { success: true, msg: `Continuing to search for devices (${nDevices} found)` });
       });
 
       discover.on('complete', () => {

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -210,9 +210,10 @@ class UiServer extends HomebridgePluginUiServer {
     const discover = new Discover(this.logger);
     return new Promise((resolve, reject) => {
       this.logger.info('Start device discovery...');
+      this.pushEvent('showToast', { success: true, msg: 'Start device discovery' });
       // If IP addresses provided then probe them directly
       ipAddrs?.forEach((ip) => {
-          discover.discoverDeviceByIP(ip);
+        discover.discoverDeviceByIP(ip);
       });
       // And then send broadcast to network(s)
       discover.startDiscover();
@@ -229,9 +230,11 @@ class UiServer extends HomebridgePluginUiServer {
             break;
         }
         devices.push(device);
+        this.pushEvent('showToast', { success: true, msg: `Discovered ${device.name} at ${device.ip}`, device: device });
       });
       discover.on('complete', () => {
         this.logger.info('Device discovery complete.');
+        this.pushEvent('showToast', { success: true, msg: 'Discovery complete' });
         resolve(devices);
       });
     });

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -217,6 +217,7 @@ class UiServer extends HomebridgePluginUiServer {
       });
       // And then send broadcast to network(s)
       discover.startDiscover();
+
       discover.on('device', async (device) => {
         switch (device.type) {
           case DeviceType.AIR_CONDITIONER:
@@ -232,6 +233,12 @@ class UiServer extends HomebridgePluginUiServer {
         devices.push(device);
         this.pushEvent('showToast', { success: true, msg: `Discovered ${device.name} at ${device.ip}`, device: device });
       });
+
+      discover.on('retry', (tries) => {
+        this.logger.info('Device discovery complete.');
+        this.pushEvent('showToast', { success: true, msg: `Continuing to search for devices...` });
+      });
+
       discover.on('complete', () => {
         this.logger.info('Device discovery complete.');
         this.pushEvent('showToast', { success: true, msg: 'Discovery complete' });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/core/MideaDiscover.ts
+++ b/src/core/MideaDiscover.ts
@@ -136,7 +136,7 @@ export default class Discover extends EventEmitter {
         this.emit('complete');
         return;
       } else {
-        this.emit('retry', tries);
+        this.emit('retry', tries, this.ips.length);
       }
       for (const ip of broadcastAddrs) {
         this.logger.debug(`Sending discovery message to ${ip}, try ${tries}...`);

--- a/src/core/MideaDiscover.ts
+++ b/src/core/MideaDiscover.ts
@@ -135,6 +135,8 @@ export default class Discover extends EventEmitter {
         this.logger.debug(`Device discovery complete after ${retries + 1} network broadcasts.`);
         this.emit('complete');
         return;
+      } else {
+        this.emit('retry', tries);
       }
       for (const ip of broadcastAddrs) {
         this.logger.debug(`Sending discovery message to ${ip}, try ${tries}...`);


### PR DESCRIPTION
What do you think of this?  I would like to provide some user feedback during the discovery process and so tested using the custom IU postEvent method.  It works pretty well.

Right now it just shows discovery start/complete and each device found.  But ideally I would like to provide a message each time the broadcast "retries" so that every couple of seconds the user gets reassurance that things are working.  I will have to provide a mechanism for MideaDiscover to callback for that though, so wanted to get your thoughts before going further.

Thanks.