### PR TITLE
Remove swing and child lock from dehumidifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -33,6 +33,7 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
   ) {
     super(platform, accessory, device, configDev);
 
+    platform.log.debug(`Dehumidifier serviceVersion: ${this.serviceVersion}, currentVersion: ${this.accessory.context.serviceVersion}`);
     this.service =
       this.accessory.getService(this.platform.Service.HumidifierDehumidifier) ||
       // We set service version in cache at same time as adding new accessory,
@@ -40,9 +41,11 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
       (((this.accessory.context.serviceVersion = this.serviceVersion) as unknown as Service) &&
         this.accessory.addService(this.platform.Service.HumidifierDehumidifier));
 
-    platform.log.debug(`Dehumidifier serviceVersion: ${this.serviceVersion}, cachedVersion: ${this.accessory.context.serviceVersion}`);
     if (this.serviceVersion !== this.accessory.context.serviceVersion) {
-      platform.log.info(`New dehumidifier service version, replacing cached version.`);
+      platform.log.info(
+        // eslint-disable-next-line max-len
+        `New dehumidifier service versiob. Upgrading from version ${this.accessory.context.serviceVersion} to version ${this.serviceVersion}.`,
+      );
       this.accessory.removeService(this.service);
       this.service = this.accessory.addService(this.platform.Service.HumidifierDehumidifier);
       this.accessory.context.serviceVersion = this.serviceVersion;

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -74,16 +74,6 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
       .onGet(this.getRotationSpeed.bind(this))
       .onSet(this.setRotationSpeed.bind(this));
 
-    this.service
-      .getCharacteristic(this.platform.Characteristic.SwingMode)
-      .onGet(this.getSwingMode.bind(this))
-      .onSet(this.setSwingMode.bind(this));
-
-    this.service
-      .getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
-      .onGet(this.getChildLockMode.bind(this))
-      .onSet(this.setChildLockMode.bind(this));
-
     this.service.getCharacteristic(this.platform.Characteristic.WaterLevel).onGet(this.getWaterLevel.bind(this));
 
     // Register a callback function with MideaDevice and then refresh device status.  The callback
@@ -122,12 +112,6 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
         case 'mode':
           updateState = true;
           break;
-        case 'swing':
-          this.service.updateCharacteristic(
-            this.platform.Characteristic.SwingMode,
-            v ? this.platform.Characteristic.SwingMode.SWING_ENABLED : this.platform.Characteristic.SwingMode.SWING_DISABLED,
-          );
-          break;
         case 'current_temperature':
           // Not currently supported
           break;
@@ -139,14 +123,6 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
           break;
         case 'water_level_set':
           // No HomeKit characteristic
-          break;
-        case 'child_lock':
-          this.service.updateCharacteristic(
-            this.platform.Characteristic.LockPhysicalControls,
-            v
-              ? this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED
-              : this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED,
-          );
           break;
         default:
           this.platform.log.warn(`[${this.device.name}] Attempt to set unsupported attribute ${k} to ${v}`);
@@ -292,33 +268,5 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
   private async getWaterLevel(): Promise<CharacteristicValue> {
     this.platform.log.debug(`[${this.device.name}] GET WaterLevel, value: ${this.device.attributes.TANK_LEVEL}`);
     return this.device.attributes.TANK_LEVEL;
-  }
-
-  // Handle requests to get the current value of the "swingMode" characteristic
-  private async getSwingMode(): Promise<CharacteristicValue> {
-    this.platform.log.debug(`[${this.device.name}] GET SwingMode, value: ${this.device.attributes.SWING}`);
-    return this.device.attributes.SWING
-      ? this.platform.Characteristic.SwingMode.SWING_ENABLED
-      : this.platform.Characteristic.SwingMode.SWING_DISABLED;
-  }
-
-  // Handle requests to set the "swingMode" characteristic
-  private async setSwingMode(value: CharacteristicValue) {
-    this.platform.log.debug(`[${this.device.name}] SET SwingMode to: ${value}`);
-    await this.device.set_attribute({ SWING: !!value });
-  }
-
-  // Handle requests to get the current value of the "LockPhysicalControls" characteristic
-  private async getChildLockMode(): Promise<CharacteristicValue> {
-    this.platform.log.debug(`[${this.device.name}] GET LockPhysicalControls, value: ${this.device.attributes.SWING}`);
-    return this.device.attributes.CHILD_LOCK
-      ? this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED
-      : this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
-  }
-
-  // Handle requests to set the "LockPhysicalControls" characteristic
-  private async setChildLockMode(value: CharacteristicValue) {
-    this.platform.log.debug(`[${this.device.name}] SET LockPhysicalControls to: ${value}`);
-    await this.device.set_attribute({ CHILD_LOCK: !!value });
   }
 }

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -33,48 +33,49 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
   ) {
     super(platform, accessory, device, configDev);
 
-    platform.log.debug(`Dehumidifier serviceVersion: ${this.serviceVersion}, currentVersion: ${this.accessory.context.serviceVersion}`);
+    platform.log.debug(
+      `[${device.name}] Dehumidifier serviceVersion: ${this.serviceVersion}, currentVersion: ${accessory.context.serviceVersion}`,
+    );
     this.service =
-      this.accessory.getService(this.platform.Service.HumidifierDehumidifier) ||
+      accessory.getService(platform.Service.HumidifierDehumidifier) ||
       // We set service version in cache at same time as adding new accessory,
       // so if/then below won't delete/add it again.
-      (((this.accessory.context.serviceVersion = this.serviceVersion) as unknown as Service) &&
-        this.accessory.addService(this.platform.Service.HumidifierDehumidifier));
+      (((accessory.context.serviceVersion = this.serviceVersion) as unknown as Service) &&
+        accessory.addService(platform.Service.HumidifierDehumidifier));
 
-    if (this.serviceVersion !== this.accessory.context.serviceVersion) {
+    if (this.serviceVersion !== accessory.context.serviceVersion) {
       platform.log.info(
-        // eslint-disable-next-line max-len
-        `New dehumidifier service versiob. Upgrading from version ${this.accessory.context.serviceVersion} to version ${this.serviceVersion}.`,
+        `[${device.name}] New dehumidifier service version. Upgrade from v${accessory.context.serviceVersion} to v${this.serviceVersion}.`,
       );
-      this.accessory.removeService(this.service);
-      this.service = this.accessory.addService(this.platform.Service.HumidifierDehumidifier);
-      this.accessory.context.serviceVersion = this.serviceVersion;
+      accessory.removeService(this.service);
+      this.service = accessory.addService(platform.Service.HumidifierDehumidifier);
+      accessory.context.serviceVersion = this.serviceVersion;
     }
 
-    this.service.setCharacteristic(this.platform.Characteristic.Name, this.device.name);
+    this.service.setCharacteristic(platform.Characteristic.Name, device.name);
 
-    this.service.getCharacteristic(this.platform.Characteristic.Active).onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
+    this.service.getCharacteristic(platform.Characteristic.Active).onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
 
     this.service
-      .getCharacteristic(this.platform.Characteristic.CurrentHumidifierDehumidifierState)
+      .getCharacteristic(platform.Characteristic.CurrentHumidifierDehumidifierState)
       .onGet(this.getCurrentHumidifierDehumidifierState.bind(this));
 
     // need to set as dehumidifier before setting validValues as defult of 0 will
     // throw error when we state that only valid value is dehumidifier (2).
     this.service.updateCharacteristic(
-      this.platform.Characteristic.TargetHumidifierDehumidifierState,
-      this.platform.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER,
+      platform.Characteristic.TargetHumidifierDehumidifierState,
+      platform.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER,
     );
     this.service
-      .getCharacteristic(this.platform.Characteristic.TargetHumidifierDehumidifierState)
+      .getCharacteristic(platform.Characteristic.TargetHumidifierDehumidifierState)
       .onGet(this.getTargetHumidifierDehumidifierState.bind(this))
       .onSet(this.setTargetHumidifierDehumidifierState.bind(this))
       .setProps({
-        validValues: [this.platform.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER],
+        validValues: [platform.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER],
       });
 
     this.service
-      .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+      .getCharacteristic(platform.Characteristic.CurrentRelativeHumidity)
       .onGet(this.getCurrentRelativeHumidity.bind(this))
       .setProps({
         minValue: 0,
@@ -83,7 +84,7 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
       });
 
     this.service
-      .getCharacteristic(this.platform.Characteristic.RelativeHumidityDehumidifierThreshold)
+      .getCharacteristic(platform.Characteristic.RelativeHumidityDehumidifierThreshold)
       .onGet(this.getRelativeHumidityDehumidifierThreshold.bind(this))
       .onSet(this.setRelativeHumidityDehumidifierThreshold.bind(this))
       .setProps({
@@ -93,7 +94,7 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
       });
 
     this.service
-      .getCharacteristic(this.platform.Characteristic.RotationSpeed)
+      .getCharacteristic(platform.Characteristic.RotationSpeed)
       .onGet(this.getRotationSpeed.bind(this))
       .onSet(this.setRotationSpeed.bind(this));
 
@@ -101,8 +102,8 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
 
     // Register a callback function with MideaDevice and then refresh device status.  The callback
     // is called whenever there is a change in any attribute value from the device.
-    this.device.on('update', this.updateCharacteristics.bind(this));
-    this.device.refresh_status();
+    device.on('update', this.updateCharacteristics.bind(this));
+    device.refresh_status();
   }
 
   /*********************************************************************

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -362,7 +362,9 @@ export default abstract class MideaDevice extends EventEmitter {
   }
 
   protected async update(values: DeviceAttributeBase) {
-    this.logger.info(`[${this.name}] Status change: ${JSON.stringify(values)}`);
+    if (this.verbose) {
+      this.logger.info(`[${this.name}] Status change: ${JSON.stringify(values)}`);
+    }
     this.emit('update', values);
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -24,6 +24,7 @@ export interface MideaAccessory extends PlatformAccessory {
     type: string;
     sn: string;
     model: string;
+    serviceVersion: number;
   };
 }
 


### PR DESCRIPTION
Fixes for issues #47 and #53 

As dehumidifiers do not have swing or child lock capabilities, remove these services from the Homebridge / HomeKit accessory.

Unfortunately this does not take effect if the accessory was already cached.  We could ask the user to manually delete the cached accessory from Homebridge, but that is very user unfriendly and everytime an accessory is deleted the whole of Homebridge is restarted (Uh? why oh why are they doing that).  Therefore I added a version test... if the cached version of the service does not match the current version (hard coded and incremented every time a breaking change is made) then the existing service is deleted and re-added.  This removes the swing/lock characteristics from the service.

In addition the info logging whenever a device update changes status is moved under a test for verbose to reduce log clutter.
