### PR TITLE
Fan only mode, minor fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "files.eol": "\n",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.rulers": [140],
   "eslint.enable": true

--- a/config.schema.json
+++ b/config.schema.json
@@ -270,11 +270,12 @@
                 "devices[].AC_options.outDoorTemp",
                 "devices[].AC_options.audioFeedback",
                 "devices[].AC_options.ecoSwitch",
+                "devices[].AC_options.breezeAwaySwitch",
                 {
-                  "key": "devices[].AC_options.switchDisplay",
+                  "key": "devices[].AC_options.displaySwitch",
                   "items": [
-                    "devices[].AC_options.switchDisplay.flag",
-                    "devices[].AC_options.switchDisplay.command"
+                    "devices[].AC_options.displaySwitch.flag",
+                    "devices[].AC_options.displaySwitch.command"
                   ]
                 },
                 "devices[].AC_options.minTemp",

--- a/config.schema.json
+++ b/config.schema.json
@@ -160,16 +160,21 @@
                   "description": "Toggles if the ECO mode switch is created with the accessory.",
                   "type": "boolean"
                 },
-                "switchDisplay": {
+                "breezeAwaySwitch": {
+                  "title": "Breeze Away Mode",
+                  "description": "Toggles if the breeze away mode swtich is created with the accessory.",
+                  "type": "boolean"
+                },
+                "displaySwitch": {
                   "type": "object",
                   "properties": {
                     "flag": {
-                      "title": "Switch Display",
+                      "title": "Display Switch",
                       "description": "Toggles if a switch, which can turn the display on or off will be created or not.",
                       "type": "boolean"
                     },
                     "command": {
-                      "title": "Switch Display Alternate Command",
+                      "title": "Display Switch Alternate Command",
                       "description": "Use this if the switch display command does not work. If it doesn't work either way then you unit does not support this feature.",
                       "type": "boolean"
                     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -121,6 +121,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (this.configDev.AC_options.switchDisplay.flag) {
       this.device.set_alternate_switch_display(this.configDev.AC_options.switchDisplay.command);
       this.displayService ??= this.accessory.addService(this.platform.Service.Switch, `${this.device.name} Display`, 'Display');
+      this.displayService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Display`);
       this.displayService
         .getCharacteristic(this.platform.Characteristic.On)
         .onGet(this.getDisplayActive.bind(this))
@@ -133,6 +134,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.ecoModeService = this.accessory.getServiceById(this.platform.Service.Switch, 'EcoMode');
     if (this.configDev.AC_options.ecoSwitch) {
       this.ecoModeService ??= this.accessory.addService(this.platform.Service.Switch, `${this.device.name} Eco`, 'EcoMode');
+      this.ecoModeService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Eco`);
       this.ecoModeService
         .getCharacteristic(this.platform.Characteristic.On)
         .onGet(this.getEcoMode.bind(this))

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -185,6 +185,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           this.service.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, v as CharacteristicValue);
           updateState = true;
           break;
+        case 'outdoor_temperature':
+          this.outDoorTemperatureService?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, v as CharacteristicValue);
+          break;
         case 'fan_speed':
           this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, v as CharacteristicValue);
           break;

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -99,6 +99,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         'Outdoor',
       );
       this.outDoorTemperatureService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Outdoor`);
+      this.outDoorTemperatureService.setCharacteristic(this.platform.Characteristic.ConfiguredName, `${this.device.name} Outdoor`);
       this.outDoorTemperatureService
         .getCharacteristic(this.platform.Characteristic.CurrentTemperature)
         .onGet(this.getOutdoorTemperature.bind(this));
@@ -118,6 +119,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (this.configDev.AC_options.fanOnlyMode) {
       this.fanService ??= this.accessory.addService(this.platform.Service.Fanv2, `${this.device.name} Fan`, 'Fan');
       this.fanService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Fan`);
+      this.fanService.setCharacteristic(this.platform.Characteristic.ConfiguredName, `${this.device.name} Fan`);
       this.fanService
         .getCharacteristic(this.platform.Characteristic.Active)
         .onGet(this.getFanOnlyMode.bind(this))
@@ -141,6 +143,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
       this.device.set_alternate_switch_display(this.configDev.AC_options.displaySwitch.command);
       this.displayService ??= this.accessory.addService(this.platform.Service.Switch, `${this.device.name} Display`, 'Display');
       this.displayService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Display`);
+      this.displayService.setCharacteristic(this.platform.Characteristic.ConfiguredName, `${this.device.name} Display`);
       this.displayService
         .getCharacteristic(this.platform.Characteristic.On)
         .onGet(this.getDisplayActive.bind(this))
@@ -154,6 +157,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (this.configDev.AC_options.ecoSwitch) {
       this.ecoModeService ??= this.accessory.addService(this.platform.Service.Switch, `${this.device.name} Eco`, 'EcoMode');
       this.ecoModeService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Eco`);
+      this.ecoModeService.setCharacteristic(this.platform.Characteristic.ConfiguredName, `${this.device.name} Eco`);
       this.ecoModeService
         .getCharacteristic(this.platform.Characteristic.On)
         .onGet(this.getEcoMode.bind(this))
@@ -167,6 +171,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (this.configDev.AC_options.breezeAwaySwitch) {
       this.breezeAwayService ??= this.accessory.addService(this.platform.Service.Switch, `${this.device.name} Breeze`, 'BreezeAway');
       this.breezeAwayService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Breeze`);
+      this.breezeAwayService.setCharacteristic(this.platform.Characteristic.ConfiguredName, `${this.device.name} Breeze`);
       this.breezeAwayService
         .getCharacteristic(this.platform.Characteristic.On)
         .onGet(() => this.device.attributes.INDIRECT_WIND)

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -41,7 +41,7 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
 
     if (service && this.accessory.context.serviceVersion !== this.serviceVersion) {
       this.platform.log.info(
-        `[${this.device.name}] New dehumidifier service version.
+        `[${this.device.name}] New dehumidifier service version.\
           Upgrade from v${this.accessory.context.serviceVersion} to v${this.serviceVersion}.`,
       );
       this.accessory.removeService(service);

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -42,7 +42,7 @@ export enum SwingMode {
 type ACOptions = {
   swingMode: SwingMode;
   ecoSwitch: boolean;
-  switchDisplay: {
+  displaySwitch: {
     flag: boolean;
     command: boolean;
   };
@@ -51,6 +51,7 @@ type ACOptions = {
   tempStep: number;
   fahrenheit: boolean;
   fanOnlyMode: boolean;
+  breezeAwaySwitch: boolean;
   outDoorTemp: boolean;
   audioFeedback: boolean;
 };
@@ -75,7 +76,7 @@ export const defaultDeviceConfig: DeviceConfig = {
   AC_options: {
     swingMode: SwingMode.NONE,
     ecoSwitch: true,
-    switchDisplay: {
+    displaySwitch: {
       flag: true,
       command: false,
     },
@@ -84,7 +85,8 @@ export const defaultDeviceConfig: DeviceConfig = {
     tempStep: 1,
     fahrenheit: false,
     fanOnlyMode: false,
-    outDoorTemp: true,
+    outDoorTemp: false,
+    breezeAwaySwitch: false,
     audioFeedback: false,
   },
   A1_options: {

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -75,7 +75,6 @@ export const defaultDeviceConfig: DeviceConfig = {
   },
   AC_options: {
     swingMode: SwingMode.NONE,
-    ecoSwitch: true,
     displaySwitch: {
       flag: true,
       command: false,
@@ -85,6 +84,7 @@ export const defaultDeviceConfig: DeviceConfig = {
     tempStep: 1,
     fahrenheit: false,
     fanOnlyMode: false,
+    ecoSwitch: false,
     outDoorTemp: false,
     breezeAwaySwitch: false,
     audioFeedback: false,


### PR DESCRIPTION
Fixes #57, #56, #55

#58 will be implemented, but I need some help:

@dkerr64 On an AC there is 6 modes: OFF, AUTO, COOL, DRY, HEAT, FAN_ONLY. If someone turn off fan only mode, what do you think should happen?

1. Turn off the AC
2. Restore the mode which was set before fan-only mode got turned on
3. Something else?

Also I thought about the OUTDOOR_TEMPERATURE, because the AC sends undefined (or an invalid) number for this field, when it was turned off for a few minutes. Currently I just return -270°C when this happens, but it's kinda ugly. Is it better if in this case the last valid value will be returned? Or I can implement fetching the current weather based on location, but it might be overkill.

