### PR TITLE
v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+# v1.0.6
+## 2024-06-15
+- BREAKING CHANGE: there is a new conifguration option `fanOnlyModeSwitch` which will only turn on fan only mode. There is a possiblity to create an accessory to manage fan only mode using option `fanAccessory`. Setting fan to auto mode can be done from the fan accessory
+- fix: NetHome Plus login
+- minor quality of life improvements

--- a/config.schema.json
+++ b/config.schema.json
@@ -219,9 +219,14 @@
                   "description": "Toggles if the temperature on the unit is displayed in Fahrenheit or Celsius.",
                   "type": "boolean"
                 },
-                "fanOnlyMode": {
-                  "title": "Fan Only Mode",
-                  "description": "Toggles if the fan only mode is created with the accessory.",
+                "fanOnlyModeSwitch": {
+                  "title": "Fan Only Mode Switch",
+                  "description": "Toggles if the fan only mode switch is created with the accessory.",
+                  "type": "boolean"
+                },
+                "fanAccessory": {
+                  "title": "Fan Accessory",
+                  "description": "Toggles if the fan accessory is created with the accessory.",
                   "type": "boolean"
                 }
               }
@@ -387,7 +392,8 @@
                 "devices[].AC_options.maxTemp",
                 "devices[].AC_options.tempStep",
                 "devices[].AC_options.fahrenheit",
-                "devices[].AC_options.fanOnlyMode"
+                "devices[].AC_options.fanOnlyModeSwitch",
+                "devices[].AC_options.fanAccessory"
               ]
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.3",
+  "version": "1.0.6-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.3",
+      "version": "1.0.6-beta.4",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.5",
+      "version": "1.0.6-beta.0",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.7",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.7",
+      "version": "1.0.6",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.6",
+  "version": "1.0.6-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.6",
+      "version": "1.0.6-beta.7",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.1",
+  "version": "1.0.6-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.1",
+      "version": "1.0.6-beta.2",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.0",
+  "version": "1.0.6-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.0",
+      "version": "1.0.6-beta.1",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.2",
+  "version": "1.0.6-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.2",
+      "version": "1.0.6-beta.3",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.4",
+  "version": "1.0.6-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.4",
+      "version": "1.0.6-beta.5",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.5",
+  "version": "1.0.6-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.0.6-beta.5",
+      "version": "1.0.6-beta.6",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.3",
+  "version": "1.0.6-beta.4",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.4",
+  "version": "1.0.6-beta.5",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.6",
+  "version": "1.0.6-beta.7",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.5",
+  "version": "1.0.6-beta.6",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.2",
+  "version": "1.0.6-beta.3",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {
@@ -35,9 +35,14 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.ts": ["prettier --write", "eslint --fix"]
+    "*.ts": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   },
-  "keywords": ["homebridge-plugin"],
+  "keywords": [
+    "homebridge-plugin"
+  ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^1.0.0",
     "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.0",
+  "version": "1.0.6-beta.1",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.1",
+  "version": "1.0.6-beta.2",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
-  "version": "1.0.6-beta.7",
+  "version": "1.0.6",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -329,7 +329,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getCurrentHeaterCoolerState(): CharacteristicValue {
-    if (this.device.attributes.POWER && this.device.attributes.MODE > 0) {
+    if (this.device.attributes.POWER && this.device.attributes.MODE > 0 && this.device.attributes.MODE < 5) {
       if (this.device.attributes.TARGET_TEMPERATURE < (this.device.attributes.INDOOR_TEMPERATURE ?? 0)) {
         if ([1, 2].includes(this.device.attributes.MODE)) {
           return this.platform.Characteristic.CurrentHeaterCoolerState.COOLING;

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -259,10 +259,6 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
       let updateState = false;
       switch (k.toLowerCase()) {
         case 'power':
-          this.service.updateCharacteristic(
-            this.platform.Characteristic.Active,
-            v ? this.platform.Characteristic.Active.ACTIVE : this.platform.Characteristic.Active.INACTIVE,
-          );
           updateState = true;
           break;
         case 'screen_display':
@@ -317,8 +313,18 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           this.platform.log.debug(`[${this.device.name}] Attempt to set unsupported attribute ${k} to ${v}`);
       }
       if (updateState) {
+        this.service.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
         this.service.updateCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState, this.getTargetHeaterCoolerState());
         this.service.updateCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState, this.getCurrentHeaterCoolerState());
+
+        this.fanOnlyService?.updateCharacteristic(this.platform.Characteristic.On, this.getFanOnlyMode());
+        this.fanService?.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
+        this.dryModeService?.updateCharacteristic(this.platform.Characteristic.On, this.getDryMode());
+        this.displayService?.updateCharacteristic(this.platform.Characteristic.On, this.getDisplayActive());
+        this.ecoModeService?.updateCharacteristic(this.platform.Characteristic.On, this.getEcoMode());
+        this.breezeAwayService?.updateCharacteristic(this.platform.Characteristic.On, this.getBreezeAway());
+        this.auxService?.updateCharacteristic(this.platform.Characteristic.On, this.getAux());
+        this.auxHeatingService?.updateCharacteristic(this.platform.Characteristic.On, this.getAuxHeating());
       }
     }
   }
@@ -327,7 +333,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
    * Callback functions for each Homebridge/HomeKit service
    *
    */
-  async getActive(): Promise<CharacteristicValue> {
+  getActive(): CharacteristicValue {
     // Show as inactive if device is off or in fan-only mode
     return this.device.attributes.POWER ? this.platform.Characteristic.Active.ACTIVE : this.platform.Characteristic.Active.INACTIVE;
   }

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -273,8 +273,8 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           this.outDoorTemperatureService?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, v as CharacteristicValue);
           break;
         case 'fan_speed':
-          this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, v as CharacteristicValue);
-          this.fanService?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, v as CharacteristicValue);
+          this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
+          this.fanService?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
           break;
         case 'fan_auto':
           this.fanService?.updateCharacteristic(
@@ -431,7 +431,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getRotationSpeed(): CharacteristicValue {
-    return this.device.attributes.FAN_SPEED;
+    return Math.min(100, this.device.attributes.FAN_SPEED ?? 0);
   }
 
   async setRotationSpeed(value: CharacteristicValue) {

--- a/src/accessory/BaseAccessory.ts
+++ b/src/accessory/BaseAccessory.ts
@@ -1,8 +1,8 @@
 import { MideaAccessory, MideaPlatform } from '../platform';
-import MideaDevice from '../core/MideaDevice';
+import MideaDevice, { DeviceAttributeBase } from '../core/MideaDevice';
 import { DeviceConfig } from '../platformUtils';
 
-export default class BaseAccessory<T extends MideaDevice> {
+export default abstract class BaseAccessory<T extends MideaDevice> {
   constructor(
     protected readonly platform: MideaPlatform,
     protected readonly accessory: MideaAccessory,
@@ -15,5 +15,11 @@ export default class BaseAccessory<T extends MideaDevice> {
       .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model ?? this.device.model)
       .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.sn ?? this.device.sn)
       .setCharacteristic(this.platform.Characteristic.ProductData, `deviceId: ${this.accessory.context.id ?? this.device.id.toString()}`);
+
+    // Register a callback function with MideaDevice and then refresh device status.  The callback
+    // is called whenever there is a change in any attribute value from the device.
+    this.device.on('update', this.updateCharacteristics.bind(this));
   }
+
+  protected abstract updateCharacteristics(attributes: DeviceAttributeBase): Promise<void>;
 }

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -152,18 +152,13 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
     } else if (this.waterTankService) {
       this.accessory.removeService(this.waterTankService);
     }
-
-    // Register a callback function with MideaDevice and then refresh device status.  The callback
-    // is called whenever there is a change in any attribute value from the device.
-    this.device.on('update', this.updateCharacteristics.bind(this));
-    this.device.refresh_status();
   }
 
   /*********************************************************************
    * Callback function called by MideaDevice whenever there is a change to
    * any attribute value.
    */
-  private async updateCharacteristics(attributes: Partial<A1Attributes>) {
+  protected async updateCharacteristics(attributes: Partial<A1Attributes>) {
     for (const [k, v] of Object.entries(attributes)) {
       this.platform.log.debug(`[${this.device.name}] Set attribute ${k} to: ${v}`);
       let updateState = false;

--- a/src/accessory/ElectricWaterHeaterAccessory.ts
+++ b/src/accessory/ElectricWaterHeaterAccessory.ts
@@ -95,16 +95,13 @@ export default class ElectricWaterHeaterAccessory extends BaseAccessory<MideaE2D
     } else if (this.wholeTankHeatingService) {
       this.accessory.removeService(this.wholeTankHeatingService);
     }
-
-    this.device.on('update', this.updateCharacteristics.bind(this));
-    this.device.refresh_status();
   }
 
   /*********************************************************************
    * Callback function called by MideaDevice whenever there is a change to
    * any attribute value.
    */
-  private async updateCharacteristics(attributes: Partial<E2Attributes>) {
+  protected async updateCharacteristics(attributes: Partial<E2Attributes>) {
     for (const [k, v] of Object.entries(attributes)) {
       this.platform.log.debug(`[${this.device.name}] Set attribute ${k} to: ${v}`);
       let updateState = false;

--- a/src/accessory/GasWaterHeaterAccessory.ts
+++ b/src/accessory/GasWaterHeaterAccessory.ts
@@ -151,16 +151,13 @@ export default class GasWaterHeaterAccessory extends BaseAccessory<MideaE3Device
     } else if (this.smartVolumeService) {
       this.accessory.removeService(this.smartVolumeService);
     }
-
-    this.device.on('update', this.updateCharacteristics.bind(this));
-    this.device.refresh_status();
   }
 
   /*********************************************************************
    * Callback function called by MideaDevice whenever there is a change to
    * any attribute value.
    */
-  private async updateCharacteristics(attributes: Partial<E3Attributes>) {
+  protected async updateCharacteristics(attributes: Partial<E3Attributes>) {
     for (const [k, v] of Object.entries(attributes)) {
       this.platform.log.debug(`[${this.device.name}] Set attribute ${k} to: ${v}`);
       let updateState = false;

--- a/src/core/MideaCloud.ts
+++ b/src/core/MideaCloud.ts
@@ -304,6 +304,8 @@ abstract class SimpleCloud<T extends SimpleSecurity> extends CloudBase<T> {
           response.data['result'] !== undefined
         ) {
           return response.data['result'];
+        } else {
+          throw new Error(`Error response from API: ${JSON.stringify(response.data)}`);
         }
       } catch (error) {
         throw new Error(`Error while sending request to ${url}: ${error}`);

--- a/src/core/MideaCloud.ts
+++ b/src/core/MideaCloud.ts
@@ -257,13 +257,13 @@ abstract class SimpleCloud<T extends SimpleSecurity> extends CloudBase<T> {
 
   buildRequestData() {
     const data = {
-      src: this.APP_ID,
-      format: 2,
-      stamp: this.timestamp(),
-      devideId: this.DEVICE_ID,
-      reqId: randomBytes(16).toString('hex'),
-      clientType: 1,
       appId: this.APP_ID,
+      format: 2,
+      clientType: 1,
+      language: this.LANGUAGE,
+      src: this.APP_ID,
+      stamp: this.timestamp(),
+      deviceId: this.DEVICE_ID,
     };
     if (this.sessionId) {
       data['sessionId'] = this.sessionId;
@@ -276,9 +276,6 @@ abstract class SimpleCloud<T extends SimpleSecurity> extends CloudBase<T> {
     const headers = {
       ...header,
     };
-    if (data['reqId'] === undefined) {
-      data['reqId'] = randomBytes(16).toString('hex');
-    }
     if (data['stamp'] === undefined) {
       data['stamp'] = this.timestamp();
     }
@@ -294,10 +291,10 @@ abstract class SimpleCloud<T extends SimpleSecurity> extends CloudBase<T> {
     if (this.access_token) {
       headers['accessToken'] = this.access_token;
     }
-
+    const payload = new URLSearchParams(data);
     for (let i = 0; i < 3; i++) {
       try {
-        const response = await axios.post(url, data, { headers: headers });
+        const response = await axios.post(url, payload.toString(), { headers: headers });
         if (
           response.data['errorCode'] !== undefined &&
           Number.parseInt(response.data['errorCode']) === 0 &&

--- a/src/core/MideaSecurity.ts
+++ b/src/core/MideaSecurity.ts
@@ -129,7 +129,7 @@ export class SimpleSecurity extends CloudSecurity {
     const parsedUrl = new URL(url);
     const path = parsedUrl.pathname;
     return createHash('sha256')
-      .update(`${path}${unescape_plus(query)}${this.LOGIN_KEY}`)
+      .update(Buffer.from(`${path}${unescape_plus(query)}${this.LOGIN_KEY}`, 'ascii'))
       .digest('hex');
   }
 }

--- a/src/devices/a1/MideaA1Device.ts
+++ b/src/devices/a1/MideaA1Device.ts
@@ -80,17 +80,17 @@ export default class MideaA1Device extends MideaDevice {
     this.attributes = {
       POWER: undefined, // invalid
       PROMPT_TONE: false,
-      CHILD_LOCK: undefined, // invalid
-      MODE: 99, // invalid
-      FAN_SPEED: 999, // invalid
+      CHILD_LOCK: undefined,
+      MODE: 0,
+      FAN_SPEED: 0,
       SWING: undefined, // invalid
-      TARGET_HUMIDITY: 999, // invalid
+      TARGET_HUMIDITY: 0,
       ANION: false,
-      TANK_LEVEL: 999, // invalid
+      TANK_LEVEL: 0,
       WATER_LEVEL_SET: 50,
-      TANK_FULL: false, // invalid
-      CURRENT_HUMIDITY: 999, // invalid
-      CURRENT_TEMPERATURE: 999, // invalid
+      TANK_FULL: false,
+      CURRENT_HUMIDITY: 0,
+      CURRENT_TEMPERATURE: 0,
       DEFROSTING: false,
       FILTER_INDICATOR: false,
       PUMP: false,

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -103,10 +103,10 @@ export default class MideaACDevice extends MideaDevice {
     super(logger, device_info, config, deviceConfig);
     this.attributes = {
       PROMPT_TONE: false,
-      POWER: undefined, // invalid
-      MODE: 99, // invalid
-      TARGET_TEMPERATURE: 999.0, // invalid
-      FAN_SPEED: 999, // invalid
+      POWER: undefined,
+      MODE: 0,
+      TARGET_TEMPERATURE: 0,
+      FAN_SPEED: 0,
       FAN_AUTO: false,
       SWING_VERTICAL: undefined, // invalid
       SWING_HORIZONTAL: undefined, // invalid

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -31,6 +31,7 @@ export interface ACAttributes extends DeviceAttributeBase {
   MODE: number;
   TARGET_TEMPERATURE: number;
   FAN_SPEED: number;
+  FAN_AUTO: boolean;
   SWING_VERTICAL: boolean | undefined;
   SWING_HORIZONTAL: boolean | undefined;
   SMART_EYE: boolean;
@@ -90,6 +91,7 @@ export default class MideaACDevice extends MideaDevice {
   private power_analysis_method?: number;
 
   private alternate_switch_display = false;
+  private last_fan_speed = 0;
 
   /*********************************************************************
    * Constructor initializes all the attributes.  We set some to invalid
@@ -105,6 +107,7 @@ export default class MideaACDevice extends MideaDevice {
       MODE: 99, // invalid
       TARGET_TEMPERATURE: 999.0, // invalid
       FAN_SPEED: 999, // invalid
+      FAN_AUTO: false,
       SWING_VERTICAL: undefined, // invalid
       SWING_HORIZONTAL: undefined, // invalid
       SMART_EYE: false,
@@ -378,6 +381,19 @@ export default class MideaACDevice extends MideaDevice {
     message.swing_vertical = swing_vertical;
     this.attributes.SWING_HORIZONTAL = swing_horizontal;
     this.attributes.SWING_VERTICAL = swing_vertical;
+    await this.build_send(message);
+  }
+
+  async set_fan_auto(fan_auto: boolean) {
+    const message = this.make_message_set();
+    if (fan_auto) {
+      // Save last fan speed before setting to auto
+      this.last_fan_speed = this.attributes.FAN_SPEED;
+    }
+    const fan_speed = fan_auto ? 102 : this.last_fan_speed;
+    message.fan_speed = fan_speed;
+    this.attributes.FAN_SPEED = fan_speed;
+    this.attributes.FAN_AUTO = fan_auto;
     await this.build_send(message);
   }
 

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -362,6 +362,7 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_target_temperature(target_temperature: number, mode?: number) {
+    this.logger.info(`[${this.name}] Set target temperature to: ${target_temperature}`);
     const message = this.make_message_unique_set();
     message.target_temperature = target_temperature;
     this.attributes.TARGET_TEMPERATURE = target_temperature;
@@ -376,6 +377,7 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_swing(swing_horizontal: boolean, swing_vertical: boolean) {
+    this.logger.info(`[${this.name}] Set swing horizontal to: ${swing_horizontal}, vertical to: ${swing_vertical}`);
     const message = this.make_message_set();
     message.swing_horizontal = swing_horizontal;
     message.swing_vertical = swing_vertical;
@@ -385,7 +387,8 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_fan_auto(fan_auto: boolean) {
-    const message = this.make_message_set();
+    this.logger.info(`[${this.name}] Set fan auto to: ${fan_auto}`);
+    const message = this.make_message_unique_set();
     if (fan_auto) {
       // Save last fan speed before setting to auto
       this.last_fan_speed = this.attributes.FAN_SPEED;

--- a/src/devices/ac/MideaACMessage.ts
+++ b/src/devices/ac/MideaACMessage.ts
@@ -407,6 +407,7 @@ class XA0MessageBody extends MessageBody {
   public target_temperature: number;
   public mode: number;
   public fan_speed: number;
+  public fan_auto: boolean;
   public swing_vertical: boolean;
   public swing_horizontal: boolean;
   public boost_mode: boolean;
@@ -426,6 +427,7 @@ class XA0MessageBody extends MessageBody {
     this.target_temperature = ((body[1] & 0x3e) >> 1) - 4 + 16.0 + ((body[1] & 0x40) > 0 ? 0.5 : 0.0);
     this.mode = (body[2] & 0xe0) >> 5;
     this.fan_speed = body[3] & 0x7f;
+    this.fan_auto = this.fan_speed === 102;
     this.swing_vertical = (body[7] & 0xc) > 0;
     this.swing_horizontal = (body[7] & 0x3) > 0;
     this.boost_mode = (body[8] & 0x20) > 0 || (body[10] & 0x2) > 0;
@@ -521,6 +523,7 @@ class XC0MessageBody extends MessageBody {
   public mode: number;
   public target_temperature: number;
   public fan_speed: number;
+  public fan_auto: boolean;
   public swing_vertical: boolean;
   public swing_horizontal: boolean;
   public boost_mode: boolean;
@@ -545,6 +548,7 @@ class XC0MessageBody extends MessageBody {
     this.mode = (body[2] & 0xe0) >> 5;
     this.target_temperature = (body[2] & 0x0f) + 16.0 + ((body[2] & 0x10) > 0 ? 0.5 : 0.0);
     this.fan_speed = body[3] & 0x7f;
+    this.fan_auto = this.fan_speed === 102;
     this.swing_vertical = (body[7] & 0x0c) > 0;
     this.swing_horizontal = (body[7] & 0x03) > 0;
     this.boost_mode = (body[8] & 0x20) > 0 || (body[10] & 0x2) > 0;
@@ -630,6 +634,7 @@ class XBBMessageBody extends MessageBody {
   public mode?: number;
   public target_temperature?: number;
   public fan_speed?: number;
+  public fan_auto?: boolean;
   public timer?: boolean;
   public eco_mode?: boolean;
   public indoor_temperature?: number;
@@ -655,6 +660,7 @@ class XBBMessageBody extends MessageBody {
       }
       this.target_temperature = (subprotocol_body[6] - 30) / 2;
       this.fan_speed = subprotocol_body[7];
+      this.fan_auto = this.fan_speed === 102;
       this.timer = subprotocol_body_len > 27 ? (subprotocol_body[25] & 0x04) > 0 : false;
       this.eco_mode = subprotocol_body_len > 27 ? (subprotocol_body[25] & 0x40) > 0 : false;
     } else if (data_type === 0x10) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -184,6 +184,7 @@ export class MideaPlatform implements DynamicPlatformPlugin {
             }
           }
           await device.connect(false);
+          await device.refresh_status();
           AccessoryFactory.createAccessory(this, existingAccessory, device, deviceConfig);
         } catch (err) {
           const msg = err instanceof Error ? err.stack : err;
@@ -207,6 +208,7 @@ export class MideaPlatform implements DynamicPlatformPlugin {
             }
           }
           await device.connect(false);
+          await device.refresh_status();
           // Set serial number and model into the context if they are provided.
           accessory.context.sn = device_info.sn ?? 'unknown';
           accessory.context.model = device_info.model ?? 'unknown';

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -59,7 +59,8 @@ type ACOptions = {
   maxTemp: number;
   tempStep: number;
   fahrenheit: boolean;
-  fanOnlyMode: boolean;
+  fanOnlyModeSwitch: boolean;
+  fanAccessory: boolean;
   breezeAwaySwitch: boolean;
   dryModeSwitch: boolean;
   auxHeatingSwitches: boolean;
@@ -98,7 +99,7 @@ type E3Options = {
 };
 
 export const defaultDeviceConfig: DeviceConfig = {
-  id: -1,
+  id: 0,
   type: '',
   advanced_options: {
     ip: '',
@@ -119,7 +120,8 @@ export const defaultDeviceConfig: DeviceConfig = {
     maxTemp: 30,
     tempStep: 1,
     fahrenheit: false,
-    fanOnlyMode: false,
+    fanOnlyModeSwitch: false,
+    fanAccessory: false,
     ecoSwitch: false,
     outDoorTemp: false,
     breezeAwaySwitch: false,


### PR DESCRIPTION
- BREAKING CHANGE: there is a new conifguration option `fanOnlyModeSwitch` which will only turn on fan only mode. There is a possiblity to create an accessory to manage fan only mode using option `fanAccessory`. Setting fan to auto mode can be done from the fan accessory
- fix: NetHome Plus login
- minor quality of life improvements