### PR TITLE
fix: login, token getting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v1.2.5
+- fix: getting tokens/key for devices
+  - IMPORTANT CHANGE: please read the [README](README.md#important-notice) about the change fetching the tokens
+
 # v1.2.4
 - feat: added support for `Humidifiers` (fixes #114)
 - fix: mark accessories as 'Not responding' if the device is presumed offline

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Pull requests and/or other offers of development assistance gratefully received.
 
 More information can be found in the [wiki](https://github.com/kovapatrik/homebridge-midea-platform/wiki).
 
+## IMPORTANT NOTICE
+- As written by [@wuwentao](https://github.com/wuwentao) in the [midea_ac_lan repository](https://github.com/wuwentao/midea_ac_lan), Midea disabled the token fetching APIs in both Meiju and Midea SmartHome, and now it's only available using the NetHome Plus API.
+- It's expected that the token fetching in NetHome Plus API will be disabled as well.
+- Make sure you save your devices' token and key to be able to usem them in the future.
+- [@wuwentao](https://github.com/wuwentao) also wrote a nice summary about the history of what happened: https://github.com/mill1000/midea-msmart/issues/201#issuecomment-2746782457
+- For these reasons, only NetHome Plus is enabled in the discovery process.
+
 ## Features
 
 Currently supports the following devices:
@@ -56,7 +63,7 @@ You should use the UI to discover and add devices. More information on the setti
 
 ## License
 
-Copyright (c) 2023 [Kovalovszky Patrik](https://github.com/kovapatrik),  
+Copyright (c) 2023 [Kovalovszky Patrik](https://github.com/kovapatrik),
 Copyright (c) 2023 [David A. Kerr](https://github.com/dkerr64)
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this program except in compliance with the License. You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/docs/download_lua.md
+++ b/docs/download_lua.md
@@ -3,7 +3,7 @@
 If you need support for a device, or a new feature for an existing one, please do the following:
 1. Open the Homebridge Config UI X
 2. Do the discovery process through the UI
-   - Here you must either use your own Midea SmartHome or Meiju account, or the default Smarthome one (if you don't have your own account in these apps)
+   - Here you must your or the default NetHome Plus account (if you don't have your own account in these apps)
 3. After the discovery ends, there will be table of discovered devices
 4. In the `Model` column, the model of your device will be a button, which you can click to download the lua script for the device.
-5. After downloading the script, open an issue about the feature you need and attach the lua script to it (or open an issue and send me the script in email, it's `kovapatrik@gmail.com`) 
+5. After downloading the script, open an issue about the feature you need and attach the lua script to it (or open an issue and send me the script in email, it's `kovapatrik@gmail.com`)

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -38,19 +38,11 @@
             <label for="useDefaultProfile" class="form-check-label">Use default Midea SmartHome profile</label>
           </div>
           <div class="mb-3" id="login">
-            <div class="mb-3">
-              <label for="registeredApp" class="form-label">Registered app</label>
-              <select id="registeredApp" class="form-select">
-                <option selected value="Midea SmartHome (MSmartHome)">Midea SmartHome (MSmartHome)</option>
-                <option value="NetHome Plus">NetHome Plus</option>
-                <option value="Meiju">Meiju</option>
-                <option value="Artison Clima">Artison Clima</option>
-              </select>
-            </div>
-            <div class="mb-3 hide bg-warning-subtle border-warning-subtle p-3 rounded-2" id="meijuWarning">
-              The Meiju app disabled the process of obtaining the required token/key pair for protocol version 3 devices. 
-              When choosing Meiju, it will utilize the default Midea SmartHome profile to retrieve the token/key pair.
-            </div>
+              <div class="mb-3 hide bg-warning-subtle border-warning-subtle p-3 rounded-2">
+                  Midea disabled the token fetching APIs in both Meiju and Midea SmartHome, and now it's only available using the NetHome Plus API.
+                  It's expected that the token fetching in NetHome Plus API will be disabled as well. Make sure you save your devices' token and key to be able to usem them in the future.
+                  From now, it's only available to login using NetHome Plus accounts.
+              </div>
             <div id="userPass">
               <div class="mb-3">
                 <label for="username" class="form-label">Username</label>
@@ -209,7 +201,6 @@
 
     const loginSection = document.getElementById('login')
     const userPass = document.getElementById('userPass');
-    const meijuWarning = document.getElementById('meijuWarning');
 
     document.getElementById('useDefaultProfile').addEventListener('change', function (e) {
       if (e.target.checked === true) {
@@ -219,18 +210,6 @@
       }
     });
 
-    document.getElementById('registeredApp').addEventListener('change', function (e) {
-      if (e.target.value === 'Meiju') {
-        meijuWarning.classList.remove('hide');
-        userPass.classList.add('disabled');
-      } else {
-        meijuWarning.classList.add('hide');
-        userPass.classList.remove('disabled');
-      }
-    });
-
-
-
     /*********************************************************************
      * Discover button clicked....
      */
@@ -239,18 +218,15 @@
 
       const username = document.getElementById('username').value;
       const password = document.getElementById('password').value;
-      const registeredApp = document.getElementById('registeredApp').value;
-      const isMeiju = registeredApp === 'Meiju';
-      const useDefaultProfile = document.getElementById('useDefaultProfile').checked === true || isMeiju;
-      
+      const useDefaultProfile = document.getElementById('useDefaultProfile').checked === true;
+
       let ipAddrs = document.getElementById('ip').value ? document.getElementById('ip').value.split(/[\s,]+/) : [];
 
       homebridge.showSpinner();
 
-
       console.info(`Request login...`);
       try {
-        await homebridge.request('/login', { username, password, registeredApp, useDefaultProfile });
+        await homebridge.request('/login', { username, password, useDefaultProfile });
       } catch (e) {
         homebridge.toast.error(e.message);
         homebridge.hideSpinner();
@@ -260,7 +236,6 @@
 
       const table = document.getElementById('discoverTable').getElementsByTagName('tbody')[0];
       table.innerHTML = '';
-
 
       // Merge current config over to the server so discover has latest device config...
       let currentConfig = await homebridge.getPluginConfig();
@@ -321,7 +296,7 @@
               window.URL.revokeObjectURL(url);
             } catch (e) {
               homebridge.toast.error(e.message);
-            } 
+            }
           });
 
           modelCell.appendChild(download_btn);

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -35,10 +35,10 @@
           </div>
           <div class="mb-3 form-check form-switch">
             <input id="useDefaultProfile" type="checkbox" class="form-check-input" role="switch">
-            <label for="useDefaultProfile" class="form-check-label">Use default Midea SmartHome profile</label>
+            <label for="useDefaultProfile" class="form-check-label">Use default NetHome Plus profile</label>
           </div>
           <div class="mb-3" id="login">
-              <div class="mb-3 hide bg-warning-subtle border-warning-subtle p-3 rounded-2">
+              <div class="mb-3 bg-warning-subtle border-warning-subtle p-3 rounded-2">
                   Midea disabled the token fetching APIs in both Meiju and Midea SmartHome, and now it's only available using the NetHome Plus API.
                   It's expected that the token fetching in NetHome Plus API will be disabled as well. Make sure you save your devices' token and key to be able to usem them in the future.
                   From now, it's only available to login using NetHome Plus accounts.

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -186,7 +186,6 @@ class UiServer extends HomebridgePluginUiServer {
             success: true,
             msg: "Currently used cloud provider doesn't support Lua downloading, using the default profile now...",
           });
-          const registeredApp = "Midea SmartHome (MSmartHome)";
           const username = Buffer.from(
             (DEFAULT_ACCOUNT[0] ^ DEFAULT_ACCOUNT[1]).toString(16),
             "hex",
@@ -198,7 +197,7 @@ class UiServer extends HomebridgePluginUiServer {
           this.cloud = CloudFactory.createCloud(
             username,
             password,
-            registeredApp,
+            "NetHome Plus",
           );
           await this.cloud.login();
         }

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -29,13 +29,13 @@ import _ from "lodash";
 
 const DEFAULT_ACCOUNT = [
   BigInt(
-    "39182118275972017797890111985649342047468653967530949796945843010512",
+    "41136566961777418441619689108052131385308997994436615360276316597550126349990",
   ),
   BigInt(
-    "29406100301096535908214728322278519471982973450672552249652548883645",
+    "41136566961777418205521495345904086238221761646585049169700858993146668339659",
   ),
   BigInt(
-    "39182118275972017797890111985649342050088014265865102175083010656997",
+    "41136566961777418441619689108052131385308997994436615362339979365072738212503",
   ),
 ];
 
@@ -109,11 +109,10 @@ class UiServer extends HomebridgePluginUiServer {
 
     this.onRequest(
       "/login",
-      async ({ username, password, registeredApp, useDefaultProfile }) => {
+      async ({ username, password, useDefaultProfile }) => {
         try {
           if (useDefaultProfile) {
             this.logger.debug("Using default profile.");
-            registeredApp = "Midea SmartHome (MSmartHome)";
             username = Buffer.from(
               (DEFAULT_ACCOUNT[0] ^ DEFAULT_ACCOUNT[1]).toString(16),
               "hex",
@@ -126,9 +125,9 @@ class UiServer extends HomebridgePluginUiServer {
           this.cloud = CloudFactory.createCloud(
             username,
             password,
-            registeredApp,
+            "NetHome Plus",
           );
-          if (username && password && registeredApp) {
+          if (username && password) {
             await this.cloud.login();
           }
         } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.2.4",
+  "version": "1.2.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.2.4",
+      "version": "1.2.5-beta.1",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.2.5-beta.2",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.2.5-beta.2",
+      "version": "1.2.5",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-midea-platform",
-  "version": "1.2.5-beta.1",
+  "version": "1.2.5-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-midea-platform",
-      "version": "1.2.5-beta.1",
+      "version": "1.2.5-beta.2",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
   "type": "module",
-  "version": "1.2.5-beta.1",
+  "version": "1.2.5-beta.2",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
   "type": "module",
-  "version": "1.2.5-beta.2",
+  "version": "1.2.5",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "displayName": "Homebridge Midea Platform",
   "name": "homebridge-midea-platform",
   "type": "module",
-  "version": "1.2.4",
+  "version": "1.2.5-beta.1",
   "description": "Homebridge plugin for Midea devices",
   "license": "Apache-2.0",
   "repository": {

--- a/src/core/MideaCloud.ts
+++ b/src/core/MideaCloud.ts
@@ -398,14 +398,14 @@ class AristonClimaCloud extends SimpleCloud<ArtisonClimaSecurity> {
 export default class CloudFactory {
   static createCloud(account: string, password: string, cloud: string): CloudBase<CloudSecurity> {
     switch (cloud) {
-      case 'Midea SmartHome (MSmartHome)':
-        return new MSmartHomeCloud(account, password);
-      case 'Meiju':
-        return new MeijuCloud(account, password);
+      // case 'Midea SmartHome (MSmartHome)':
+      //   return new MSmartHomeCloud(account, password);
+      // case 'Meiju':
+      //   return new MeijuCloud(account, password);
       case 'NetHome Plus':
         return new NetHomePlusCloud(account, password);
-      case 'Ariston Clima':
-        return new AristonClimaCloud(account, password);
+      // case 'Ariston Clima':
+      //   return new AristonClimaCloud(account, password);
       default:
         throw new Error(`Cloud ${cloud} is not supported.`);
     }


### PR DESCRIPTION
- As written by [@wuwentao](https://github.com/wuwentao) in the [midea_ac_lan repository](https://github.com/wuwentao/midea_ac_lan), Midea disabled the token fetching APIs in both Meiju and Midea SmartHome, and now it's only available using the NetHome Plus API.
- It's expected that the token fetching in NetHome Plus API will be disabled as well.
- Make sure you save your devices' token and key to be able to usem them in the future.
- [@wuwentao](https://github.com/wuwentao) also wrote a nice summary about the history of what happened: https://github.com/mill1000/midea-msmart/issues/201#issuecomment-2746782457
- For these reasons, only NetHome Plus is enabled in the discovery process.