### PR TITLE
Added an auto mode switch

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -218,6 +218,11 @@
                   "description": "Toggles if the ECO mode switch is created with the accessory.",
                   "type": "boolean"
                 },
+                "autoModeSwitch": {
+                  "title": "Create auto mode seperately",
+                  "description": "Devices with cooling only capabilities have an auto mode that serves a different function, turn this on to move auto mode to a switch accessory.",
+                  "type": "boolean"
+                },
                 "dryModeSwitch": {
                   "title": "Dry Mode Switch",
                   "description": "Toggles if the dry mode switch is created with the accessory.",
@@ -632,6 +637,7 @@
                 "devices[].AC_options.screenOff",
                 "devices[].AC_options.ecoSwitch",
                 "devices[].AC_options.breezeAwaySwitch",
+                "devices[].AC_options.autoModeSwitch",
                 "devices[].AC_options.dryModeSwitch",
                 "devices[].AC_options.boostModeSwitch",
                 "devices[].AC_options.auxHeatingSwitches",

--- a/docs/ac.md
+++ b/docs/ac.md
@@ -14,6 +14,7 @@ Providing air conditioner settings is optional and the whole section or individu
     "audioFeedback": false,
     "screenOff": false,
     "ecoSwitch": false,
+    "autoModeSwitch": false,
     "dryModeSwitch": false,
     "boostModeSwitch": false,
     "breezeAwaySwitch": false,
@@ -45,6 +46,7 @@ Providing air conditioner settings is optional and the whole section or individu
 - **audioFeedback** *(optional)*: Toggles if the unit beeps when a command is sent, default is false.
 - **screenOff** *(optional)*: Toggles if the screen is turned off by default when the unit is turned on. Default is `false`.
 - **ecoSwitch** *(optional)*: Toggles if the eco switch is created with the accessory. Default is `false`.
+- **autoModeSwitch** *(optional)*: Seperates auto mode into it's own accessory. Default is `false`.
 - **dryModeSwitch** *(optional)*: Toggles if the dry mode switch is created with the accessory. Default is `false`.
 - **boostModeSwitch** *(optional)*: Toggles if the boost/turbo mode switch is created with the accessory. Default is `false`.
 - **breezeAwaySwitch** *(optional)*: Toggles if the breeze away switch is created with the accessory. Default is `false`.

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -75,6 +75,7 @@ type ACOptions = {
   fanOnlyModeSwitch: boolean;
   fanAccessory: boolean;
   breezeAwaySwitch: boolean;
+  autoModeSwitch: boolean;
   dryModeSwitch: boolean;
   boostModeSwitch: boolean;
   auxHeatingSwitches: boolean;
@@ -180,6 +181,7 @@ export const defaultDeviceConfig: DeviceConfig = {
     audioFeedback: false,
     screenOff: false,
     ecoSwitch: false,
+    autoModeSwitch: false,
     dryModeSwitch: false,
     boostModeSwitch: false,
     breezeAwaySwitch: false,


### PR DESCRIPTION
#135 

The HeaterCooler Accessory's definition of 'Auto' is different to Midea's definition (at least for the units that don't have heating functionality). The HeaterCooler uses 'Auto' to mean "balance heating and cooling to meet the target temperature", while Midea uses it to control fan speed.

This fixes the janky behavior that results from that mismatch by giving the option to select auto mode in a switch instead.