### PR TITLE
feat(AC): Add option to expose humidity sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -327,6 +327,11 @@
                   "title": "Indoor Temperature Sensor",
                   "description": "Toggles if a seperated indoor temperature is created with the accessory. This sensor can be used for automations as for some reason the internal sensors are not usable for this.",
                   "type": "boolean"
+                },
+                "humiditySensor": {
+                  "title": "Humidity Sensor",
+                  "description": "Toggles if a separate humidity sensor is created with the accessory. This sensor can be used for automations.",
+                  "type": "boolean"
                 }
               }
             },

--- a/config.schema.json
+++ b/config.schema.json
@@ -730,7 +730,8 @@
                 "devices[].AC_options.fanAutoSwitch",
                 "devices[].AC_options.sleepModeSwitch",
                 "devices[].AC_options.comfortModeSwitch",
-                "devices[].AC_options.temperatureSensor"
+                "devices[].AC_options.temperatureSensor",
+                "devices[].AC_options.humiditySensor"
               ]
             },
             {

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -374,7 +374,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.humiditySensorService = this.accessory.getServiceById(this.platform.Service.HumiditySensor, humiditySensorSubtype);
     if (this.configDev.AC_options.humiditySensor) {
       this.humiditySensorService ??= this.accessory.addService(this.platform.Service.HumiditySensor, undefined, humiditySensorSubtype);
-      this.handleConfiguredName(this.humiditySensorService, humiditySensorSubtype, 'Humidity');
+      this.humiditySensorService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Humidity`);
       this.humiditySensorService
         .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
         .onGet(this.getIndoorHumidity.bind(this));

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -33,6 +33,7 @@ const sleepModeSubtype = 'sleepMode';
 const swingAngleSubtype = 'swingAngle';
 const comfortModeSubtype = 'comfortMode';
 const temperatureSensorSubtype = 'temperatureSensor';
+const humiditySensorSubtype = 'humidity';
 
 export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice> {
   protected service: Service;
@@ -55,6 +56,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   private swingAngleService?: Service;
   private comfortModeService?: Service;
   private temperatureSensorService?: Service;
+  private humiditySensorService?: Service;
 
   private swingAngleMainControl: SwingAngle;
   private heatingThresholdTemperature: number;
@@ -368,6 +370,18 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
       this.accessory.removeService(this.temperatureSensorService);
     }
 
+    // Separate humidity sensor accessory
+    this.humiditySensorService = this.accessory.getServiceById(this.platform.Service.HumiditySensor, humiditySensorSubtype);
+    if (this.configDev.AC_options.humiditySensor) {
+      this.humiditySensorService ??= this.accessory.addService(this.platform.Service.HumiditySensor, undefined, humiditySensorSubtype);
+      this.handleConfiguredName(this.humiditySensorService, humiditySensorSubtype, 'Humidity');
+      this.humiditySensorService
+        .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+        .onGet(this.getIndoorHumidity.bind(this));
+    } else if (this.humiditySensorService) {
+      this.accessory.removeService(this.humiditySensorService);
+    }
+
     const swingProps = this.configDev.AC_options.swing;
     this.swingAngleMainControl =
       swingProps.mode === SwingMode.VERTICAL || (swingProps.mode === SwingMode.BOTH && swingProps.angleMainControl === SwingAngle.VERTICAL)
@@ -466,6 +480,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           }
           break;
         }
+        case 'indoor_humidity':
+          this.humiditySensorService?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.getIndoorHumidity());
+          break;
         case 'outdoor_temperature':
           this.outDoorTemperatureService?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, this.getOutdoorTemperature());
           break;
@@ -821,6 +838,10 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setRotationSpeed(value: CharacteristicValue) {
     await this.device.set_attribute({ FAN_SPEED: value as number });
+  }
+
+  getIndoorHumidity(): CharacteristicValue {
+    return this.device.attributes.INDOOR_HUMIDITY ?? 0;
   }
 
   getOutdoorTemperature(): CharacteristicValue {

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -374,7 +374,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.humiditySensorService = this.accessory.getServiceById(this.platform.Service.HumiditySensor, humiditySensorSubtype);
     if (this.configDev.AC_options.humiditySensor) {
       this.humiditySensorService ??= this.accessory.addService(this.platform.Service.HumiditySensor, undefined, humiditySensorSubtype);
-      this.humiditySensorService.setCharacteristic(this.platform.Characteristic.Name, `${this.device.name} Humidity`);
+      this.handleConfiguredName(this.humiditySensorService, humiditySensorSubtype, 'Humidity');
       this.humiditySensorService
         .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
         .onGet(this.getIndoorHumidity.bind(this));

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -105,6 +105,7 @@ type ACOptions = {
   sleepModeSwitch: boolean;
   comfortModeSwitch: boolean;
   temperatureSensor: boolean;
+  humiditySensor: boolean;
 };
 
 type A1Options = {
@@ -231,7 +232,8 @@ export const defaultDeviceConfig: DeviceConfig = {
     fanAutoSwitch: false,
     sleepModeSwitch: false,
     comfortModeSwitch: false,
-    temperatureSensor: false
+    temperatureSensor: false,
+    humiditySensor: false,
   },
   A1_options: {
     temperatureSensor: false,


### PR DESCRIPTION
Hey @kovapatrik, thanks for the plugin! In the process of deploying it across 4 AC units, I noticed that the humidity shown in the Midea SmartHome app for each unit isn't exposed to HomeKit — this PR adds a new option in the AC config to do that (tested and working across my 4 units)