### PR TITLE
Fix custom IP validation false negatives from stateful global regex

### DIFF
--- a/src/homebridge-ui/ui.ts
+++ b/src/homebridge-ui/ui.ts
@@ -124,7 +124,7 @@ Alpine.data('discoverApp', () => {
       }
       ipAddrs = [...new Set(ipAddrs)];
 
-      const ipRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/gi;
+      const ipRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/i;
       if (ipAddrs.length > 0 && !ipAddrs.every((ip) => ipRegex.test(ip))) {
         homebridge.toast.error('Invalid IP address provided');
         return;


### PR DESCRIPTION
## Summary
- Fixes #193: custom IP validation in the config UI intermittently rejected valid IPv4 addresses.
- Root cause: `ipRegex` in `src/homebridge-ui/ui.ts` (`discover()`) had the `/g` flag while being reused across multiple `.test()` calls via `.every()`. Global regexes are stateful (`lastIndex` persists between calls), so after matching one IP, the next `.test()` call on a different string starts past that string's end and incorrectly fails — even for valid IPs like `192.168.1.174`.
- This was triggered in practice because `ipAddrs` includes both the freshly typed IP and every already-configured device's IP, so entering a custom IP while at least one device already exists was enough to hit the bug.
- Fix: drop the unnecessary `/g` flag (the pattern is anchored with `^...$` and used only with `.test()`, so global matching serves no purpose).

## Test plan
- [ ] Confirm `ipRegex.test('192.168.1.174')` returns `true` on repeated calls with mixed IP strings
- [ ] In the Homebridge config UI, add a device with an IP, then enter a second custom IP for discovery and confirm no false "Invalid IP address provided" error
