### PR TITLE
fix: reconnect retry after failed handshake, and quiet the recoverable log

### DIFF
--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -454,7 +454,8 @@ export default abstract class MideaDevice extends EventEmitter {
           if (this.promiseSocket) {
             this.promiseSocket.destroy();
           }
-          this.promiseSocket = new PromiseSocket(this.logger, this.logRecoverableErrors);
+          // Keep the destroyed socket so the loop retries; a fresh socket here would
+          // exit the reconnect loop (destroyed === false) without ever connecting.
         }
         const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
         await sleep(5000);

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -449,7 +449,11 @@ export default abstract class MideaDevice extends EventEmitter {
           break; // Exit reconnect loop
         } catch (err) {
           const msg = err instanceof Error ? err.stack : err;
-          this.logger.warn(`[${this.name}] Reconnect failed: ${msg}`);
+          if (this.logRecoverableErrors) {
+            this.logger.warn(`[${this.name}] Reconnect failed: ${msg}`);
+          } else {
+            this.logger.debug(`[${this.name}] Reconnect failed: ${msg}`);
+          }
           this._authenticated = false;
           if (this.promiseSocket) {
             this.promiseSocket.destroy();


### PR DESCRIPTION
## What does this PR do?

Two related fixes in the reconnect path of `MideaDevice.run()`. Both showed up on my A1 dehumidifiers, which intermittently fail the handshake on reconnect ("Data length mismatch") roughly once or twice an hour and recover on their own.

**1. Keep the destroyed socket after a failed reconnect (the actual bug, #192).**
When a reconnect attempt failed, the catch block destroyed the failed socket but then immediately replaced it with a fresh `PromiseSocket`. The fresh socket reports `destroyed === false`, so the reconnect loop exited as if the connection had been restored, and the run loop started polling a socket that was never connected. Every heartbeat, status refresh and HomeKit command for the next ~120 seconds was dropped by the `send_message_v3` auth guard ("Cannot send V3 message ... Dropping message"), until the heartbeat timeout finally closed the socket and reconnection restarted. Removing the reassignment lets the destroyed socket stay in place, so the loop keeps retrying every 5 seconds and the next attempt creates its own socket at the top of the loop, exactly as a normal reconnect already does.

**2. Gate the "Reconnect failed" log behind `logRecoverableErrors`.**
A failed reconnect is a recoverable condition now that the loop retries cleanly, so logging a `warn` stack trace on every transient handshake blip is noise. This gates it (warn when `logRecoverableErrors` is on, debug otherwise), matching the neighbouring "Heartbeat timeout, closing" and "Create new socket, reconnect" lines that already follow this pattern.

The intermittent handshake failure that triggers all this is a separate root cause and is not fixed here. With these changes it costs a silent 5 second retry instead of a 2 minute window of dropped messages plus a stack trace.

## How was it tested?

`npm run lint`, `npm run fmt:check` and `npm run build` all pass clean.

The dead-socket fix (1) is confirmed on hardware: before it, every "Data length mismatch" was followed by ~15 "Cannot send V3 message ... Dropping message" lines over ~120s; after deploying this branch, the same failures now appear as isolated one-off events with zero dropped-message lines and the device recovers within seconds. The log gating (2) is a straightforward level change matching existing siblings.

## AI assistance disclosure

Assisted-by: Claude Code

---

**Checklist**

- [x] I read the [contribution guidelines](/CONTRIBUTING.md)
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](/CONTRIBUTING.md#ai-policy)
- [x] I tested this on real hardware (required for device-specific changes)
- [x] I ran `npm run lint` and `npm run fmt:check` and there are no warnings
