### PR TITLE
fix: remove disabled swing angle accessory

### DIFF
--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -428,6 +428,8 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           .onGet(this.getSwingAngleTargetVerticalTiltAngle.bind(this))
           .onSet(this.setSwingAngleTargetVerticalTiltAngle.bind(this));
       }
+    } else if (this.swingAngleService) {
+      this.accessory.removeService(this.swingAngleService);
     }
     // Misc
     this.device.attributes.PROMPT_TONE = configDev.AC_options.audioFeedback;


### PR DESCRIPTION
## Summary

- remove the cached swing angle service when `angleAccessory` is disabled or swing mode is set to `None`
- align the swing angle accessory lifecycle with the other optional air conditioner services

## Root cause

The plugin restores the existing `swingAngle` `WindowCovering` service from the Homebridge accessory cache, but only handles the enabled configuration path. After changing `angleAccessory` from `true` to `false`, the cached service is never removed and remains visible in HomeKit across restarts.

This is the same service lifecycle pattern previously fixed for the outdoor temperature service in #50. The swing angle accessory was introduced in #92 without the corresponding disabled-state cleanup.

## User impact

Disabling the swing angle accessory now removes the stale Swing service on the next Homebridge or child bridge restart, without requiring users to reset the entire cached accessory.

## Validation

- `npm run fmt:check`
- `npm run lint`
- `npm run build`
- Validate on my homebridge instance and works as expect
