### PR TITLE
fix: report failed device updates to HomeKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "rimraf ./dist && tsc && npm run build:ui",
     "build:ui": "rolldown -c rolldown.config.ts",
     "prepublishOnly": "npm run lint && npm run fmt:check && npm run build",
+    "test": "tsx --test test/*.test.js",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check"
   },

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -218,8 +218,7 @@ export default abstract class MideaDevice extends EventEmitter {
 
   private async send_message_v3(data: Buffer, message_type: TCPMessageType = TCPMessageType.ENCRYPTED_REQUEST) {
     if (!this._authenticated) {
-      this.logger.warn(`[${this.name}] Cannot send V3 message — not authenticated. Dropping message.`);
-      return;
+      throw new Error(`[${this.name}] Cannot send V3 message — not authenticated.`);
     }
     const encrypted_data = this.security.encode_8370(data, message_type);
     await this.send_message_v2(encrypted_data);
@@ -288,6 +287,7 @@ export default abstract class MideaDevice extends EventEmitter {
         return false;
       }
     } catch (err) {
+      this.emit('error_refresh');
       const msg = err instanceof Error ? err.stack : err;
       if (this.logRecoverableErrors) {
         this.logger.warn(`[${this.name} | refresh_status] Recoverable error:\n${msg}`);

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -306,6 +306,8 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_attribute(attributes: Partial<ACAttributes>) {
+    const previousAttributes = { ...this.attributes };
+    const previousLastFanSpeed = this.last_fan_speed;
     const messageToSend: {
       GENERAL: MessageGeneralSet | MessageSubProtocolSet | undefined;
       NEW_PROTOCOL: MessageNewProtocolSet | undefined;
@@ -416,16 +418,23 @@ export default class MideaACDevice extends MideaDevice {
           this.logger.debug(`[${this.name}] Tried to set ${k} to: ${v}, but it's not allowed.`);
         }
       }
+      let messageSent = false;
       for (const [k, v] of Object.entries(messageToSend)) {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
+          messageSent = true;
         }
       }
+      if (messageSent) {
+        this.update(attributes);
+      }
     } catch (err) {
+      this.attributes = previousAttributes;
+      this.last_fan_speed = previousLastFanSpeed;
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);
+      throw err;
     }
   }
 
@@ -437,15 +446,16 @@ export default class MideaACDevice extends MideaDevice {
     this.logger.info(`[${this.name}] Set target temperature to: ${target_temperature}`);
     const message = this.make_message_unique_set();
     message.target_temperature = target_temperature;
-    this.attributes.TARGET_TEMPERATURE = target_temperature;
     if (mode) {
       message.mode = mode;
       message.power = true;
-
+    }
+    await this.build_send(message);
+    this.attributes.TARGET_TEMPERATURE = target_temperature;
+    if (mode) {
       this.attributes.MODE = mode;
       this.attributes.POWER = true;
     }
-    await this.build_send(message);
   }
 
   async set_swing(swing_horizontal: boolean, swing_vertical: boolean) {
@@ -453,11 +463,11 @@ export default class MideaACDevice extends MideaDevice {
     const message = this.make_message_set();
     message.swing_horizontal = swing_horizontal;
     message.swing_vertical = swing_vertical;
+    await this.build_send(message);
     this.attributes.SWING_HORIZONTAL = swing_horizontal;
     this.attributes.SWING_VERTICAL = swing_vertical;
     this.attributes.WIND_SWING_LR_ANGLE = 0;
     this.attributes.WIND_SWING_UD_ANGLE = 0;
-    await this.build_send(message);
   }
 
   private disable_all_fan_related_modes(message: MessageGeneralSet | MessageSubProtocolSet) {
@@ -485,6 +495,8 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_fan_auto(fan_auto: boolean) {
+    const previousAttributes = { ...this.attributes };
+    const previousLastFanSpeed = this.last_fan_speed;
     this.logger.info(`[${this.name}] Set fan auto to: ${fan_auto}`);
     const message = this.make_message_unique_set();
 
@@ -498,7 +510,13 @@ export default class MideaACDevice extends MideaDevice {
     message.fan_speed = fan_speed;
     this.attributes.FAN_SPEED = fan_speed;
     this.attributes.FAN_AUTO = fan_auto;
-    await this.build_send(message);
+    try {
+      await this.build_send(message);
+    } catch (err) {
+      this.attributes = previousAttributes;
+      this.last_fan_speed = previousLastFanSpeed;
+      throw err;
+    }
   }
 
   set_fan_speed(fan_speed: number, message: MessageGeneralSet | MessageSubProtocolSet) {
@@ -553,47 +571,50 @@ export default class MideaACDevice extends MideaDevice {
   async set_swing_angle(swing_direction: SwingAngle, swing_angle: number) {
     this.logger.info(`[${this.name}] Set swing ${swing_direction} angle to: ${swing_angle}`);
     const message = new MessageNewProtocolSet(this.device_protocol_version);
-    this.attributes.SWING_HORIZONTAL = false;
-    this.attributes.SWING_VERTICAL = false;
     switch (swing_direction) {
       case SwingAngle.HORIZONTAL:
         message.wind_swing_lr_angle = swing_angle;
-        this.attributes.WIND_SWING_LR_ANGLE = swing_angle;
         break;
       case SwingAngle.VERTICAL:
         message.wind_swing_ud_angle = swing_angle;
-        this.attributes.WIND_SWING_UD_ANGLE = swing_angle;
         break;
     }
     message.prompt_tone = this.attributes.PROMPT_TONE;
     await this.build_send(message);
+    this.attributes.SWING_HORIZONTAL = false;
+    this.attributes.SWING_VERTICAL = false;
+    if (swing_direction === SwingAngle.HORIZONTAL) {
+      this.attributes.WIND_SWING_LR_ANGLE = swing_angle;
+    } else {
+      this.attributes.WIND_SWING_UD_ANGLE = swing_angle;
+    }
   }
 
   async set_self_clean(self_clean: boolean) {
     this.logger.info(`[${this.name}] Set self clean to: ${self_clean}`);
     const message = new MessageNewProtocolSet(this.device_protocol_version);
     message.self_clean = self_clean;
-    this.attributes.SELF_CLEAN = self_clean;
     message.prompt_tone = this.attributes.PROMPT_TONE;
     await this.build_send(message);
+    this.attributes.SELF_CLEAN = self_clean;
   }
 
   async set_rate_select(rate_select: number) {
     this.logger.info(`[${this.name}] Set rate select to: ${rate_select}`);
     const message = new MessageNewProtocolSet(this.device_protocol_version);
     message.rate_select = rate_select;
-    this.attributes.RATE_SELECT = rate_select;
     message.prompt_tone = this.attributes.PROMPT_TONE;
     await this.build_send(message);
+    this.attributes.RATE_SELECT = rate_select;
   }
 
   async set_out_silent(out_silent: boolean) {
     this.logger.info(`[${this.name}] Set out silent to: ${out_silent}`);
     const message = new MessageNewProtocolSet(this.device_protocol_version);
     message.out_silent = out_silent;
-    this.attributes.OUT_SILENT = out_silent;
     message.prompt_tone = this.attributes.PROMPT_TONE;
     await this.build_send(message);
+    this.attributes.OUT_SILENT = out_silent;
   }
 
   protected set_subtype(): void {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -135,6 +135,14 @@ export class MideaPlatform implements DynamicPlatformPlugin {
       if (!this.discoveredDevices.get(device.id)) {
         // This device was not found by network discovery.
         missingDevices++;
+        const accessory = this.accessories.get(this.api.hap.uuid.generate(device.id.toString()));
+        const service = accessory?.services.find((cachedService) => cachedService.UUID !== this.Service.AccessoryInformation.UUID);
+        const characteristic = [this.Characteristic.Active, this.Characteristic.On, this.Characteristic.CurrentHeatingCoolingState].find((candidate) =>
+          service?.testCharacteristic(candidate),
+        );
+        if (service && characteristic) {
+          service.updateCharacteristic(characteristic, new Error('Device not found'));
+        }
         if (this.discoveredDevices.get(device.id) === undefined) {
           this.discoveredDevices.set(device.id, false);
           this.log.warn(`[${device.name}] Device not found (id: ${device.id}), will retry every ${this.discoveryInterval} seconds`);
@@ -196,11 +204,20 @@ export class MideaPlatform implements DynamicPlatformPlugin {
               device.setCredentials(Buffer.from(existingAccessory.context.token, 'hex'), Buffer.from(existingAccessory.context.key, 'hex'));
             }
           }
-          await device.connect(true);
+          if (!(await device.connect(true))) {
+            throw new Error(`Cannot connect to device ${device_info.ip}:${device_info.port}`);
+          }
           createAccessory(this, existingAccessory, device, deviceConfig);
         } catch (err) {
           const msg = err instanceof Error ? err.stack : err;
           this.log.error(`Cannot connect to device from cache ${device_info.ip}:${device_info.port}, error:\n${msg}`);
+          const service = existingAccessory.services.find((cachedService) => cachedService.UUID !== this.Service.AccessoryInformation.UUID);
+          const characteristic = [this.Characteristic.Active, this.Characteristic.On, this.Characteristic.CurrentHeatingCoolingState].find((candidate) =>
+            service?.testCharacteristic(candidate),
+          );
+          if (service && characteristic) {
+            service.updateCharacteristic(characteristic, new Error('Cannot connect to device'));
+          }
         }
       } else {
         try {

--- a/test/device-errors.test.js
+++ b/test/device-errors.test.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DeviceType, ProtocolVersion } from '../src/core/MideaConstants.ts';
+import MideaACDevice from '../src/devices/ac/MideaACDevice.ts';
+import { MideaPlatform } from '../src/platform.ts';
+import { defaultConfig, defaultDeviceConfig } from '../src/platformUtils.ts';
+
+const logger = {
+  debug() {},
+  error() {},
+  info() {},
+  warn() {},
+};
+
+function createDevice() {
+  return new MideaACDevice(
+    logger,
+    {
+      ip: '127.0.0.1',
+      port: 6444,
+      id: 1,
+      model: 'test',
+      sn: 'test',
+      name: 'Test AC',
+      type: DeviceType.AIR_CONDITIONER,
+      version: ProtocolVersion.V3,
+    },
+    structuredClone(defaultConfig),
+    structuredClone(defaultDeviceConfig),
+  );
+}
+
+test('rejects V3 commands while unauthenticated', async () => {
+  const device = createDevice();
+
+  await assert.rejects(device.send_message(Buffer.alloc(0)), /not authenticated/);
+});
+
+test('restores AC attributes when a command fails', async () => {
+  const device = createDevice();
+  device.attributes.POWER = false;
+  device.build_send = async () => {
+    throw new Error('send failed');
+  };
+
+  await assert.rejects(device.set_attribute({ POWER: true }), /send failed/);
+  assert.equal(device.attributes.POWER, false);
+});
+
+test('reports refresh errors to accessories', async () => {
+  const device = createDevice();
+  device.build_send = async () => {
+    throw new Error('send failed');
+  };
+  const refreshError = new Promise((resolve) => device.once('error_refresh', resolve));
+
+  assert.equal(await device.refresh_status(), false);
+  await refreshError;
+});
+
+test('marks cached accessories unavailable when discovery misses them', (t) => {
+  t.mock.method(globalThis, 'setTimeout', () => 0);
+  let characteristicError;
+  const mainService = {
+    UUID: 'main-service',
+    testCharacteristic: (characteristic) => characteristic === 'active',
+    updateCharacteristic: (_characteristic, error) => {
+      characteristicError = error;
+    },
+  };
+  const platform = Object.assign(Object.create(MideaPlatform.prototype), {
+    Characteristic: {
+      Active: 'active',
+      On: 'on',
+      CurrentHeatingCoolingState: 'current-heating-cooling-state',
+    },
+    Service: { AccessoryInformation: { UUID: 'accessory-information' } },
+    accessories: new Map([['device-1', { services: [{ UUID: 'accessory-information' }, mainService] }]]),
+    api: { hap: { uuid: { generate: () => 'device-1' } } },
+    discover: { startDiscover() {} },
+    discoveredDevices: new Map(),
+    discoveryInterval: 60,
+    log: logger,
+    platformConfig: { devices: [{ id: 1, name: 'Test AC' }] },
+  });
+
+  platform.discoveryComplete();
+
+  assert.match(characteristicError.message, /Device not found/);
+});


### PR DESCRIPTION
## Summary

- reject unauthenticated V3 writes so HomeKit receives a service communication failure
- restore AC attributes when a command fails and publish optimistic updates only after every message is sent
- emit refresh errors and mark cached accessories unavailable when discovery or startup connection fails
- add regression coverage for command, refresh, and discovery failures

## Context

Previously, an unauthenticated V3 command was logged and dropped while the setter resolved successfully. AC attributes had already been updated locally, so HomeKit displayed the requested state even though the device never received it. Cached accessories also retained their previous state when a device was missing during startup discovery.

This complements #197: that pull request fixes the reconnect loop, while this one makes failed writes and unavailable devices visible to HomeKit. It does not include the reconnect-loop change.

## Validation

- npm test
- npm run fmt:check
- npm run lint
- npm run build
- loaded the compiled patch in a Homebridge 2.3.0 child bridge with four V3 AC devices; all four were discovered and authenticated after restart