### PR TITLE
:zap: Configure plugins to be compatible with Midea portasplit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.3.4](https://github.com/kovapatrik/homebridge-midea-platform/compare/v1.3.3...v1.3.4) (2026-08-14)
+
+### Bug Fixes
+* Fixed a crash during accessory restoration from cache caused by duplicate Eve energy characteristics being added to the `Outlet` service.
+* Resolved `TypeError` crashes during startup and status updates by ensuring services are fully initialized before processing events.
+* Fixed `NaN` and "illegal value" warnings for temperature thresholds and fan speed by correctly ordering characteristic property and value initialization.
+* Improved HAP compliance by removing non-standard characteristics (`ConfiguredName`, `TargetFanState`, `CurrentRelativeHumidity` in certain services) to eliminate Homebridge warnings.
+* Enhanced robustness of `limitValue` utility to handle non-numeric inputs gracefully.
+
+### Documentation
+* Updated AC documentation and configuration schema to clarify that `humiditySensor` option is required to see indoor humidity in HomeKit.
+
 ## [1.3.3](https://github.com/kovapatrik/homebridge-midea-platform/compare/v1.3.2...v1.3.3) (2026-07-07)
 
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,40 @@
+### Migration Guide to @jouskaio/homebridge-midea-portasplit
+
+To make your modifications permanent and prevent Homebridge from overwriting your plugin during an official version update, we have renamed the plugin to `@jouskaio/homebridge-midea-portasplit`.
+
+#### 1. Official Installation
+
+The plugin is now officially available on npm. You can install it directly from the Homebridge interface:
+
+1. Go to the **Plugins** tab.
+2. Search for `@jouskaio/homebridge-midea-portasplit`.
+3. Click **Install**.
+
+Alternatively, via the command line on your server:
+
+```bash
+sudo npm install -g @jouskaio/homebridge-midea-portasplit
+```
+
+#### 2. Cleaning up the old version
+
+On your Homebridge server (via SSH), it is recommended to delete the old official version to avoid any conflict:
+
+```bash
+sudo hb-service uninstall homebridge-midea-platform
+```
+
+_(Or `npm uninstall -g homebridge-midea-platform` if you are not using hb-service)_
+
+#### 3. Homebridge Configuration
+
+Your `config.json` file already uses `midea-platform` as the platform alias. Since this name has not changed, the new plugin should pick up your configuration automatically.
+
+#### 4. HomeKit (Important)
+
+Changing the plugin name may cause your devices to reappear in HomeKit as new accessories.
+
+- If your devices disappear, they will likely be in the "Default Room" of the Home app.
+- You will need to move them back to their respective rooms and potentially recreate your linked scenes/automations.
+
+This is a one-time necessary step to ensure that no future official updates will overwrite your work.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
   <a href="https://github.com/homebridge/verified/blob/master/verified-plugins.json"><img alt="Homebridge Verified" src="./branding/Homebridge_x_Midea.svg" width="500px"></a>
 </p>
 
-# homebridge-midea-platform
+# @jouskaio/homebridge-midea-portasplit
 
-[![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
-[![npm](https://badgen.net/npm/v/homebridge-midea-platform)](https://www.npmjs.com/package/homebridge-midea-platform)
-[![npm](https://badgen.net/npm/dt/homebridge-midea-platform?label=downloads)](https://www.npmjs.com/package/homebridge-midea-platform)
-
-_Verified_ plugin for Midea devices. This is implemented by building on the Homebridge platform plugin template and the work done by:
+_Custom version_ for Midea devices. Developed by [Jouskaio](https://github.com/Jouskaio). Based on the original work by [kovapatrik](https://github.com/kovapatrik/homebridge-midea-platform).
 
 - [@georgezhao2010](https://github.com/georgezhao2010) in the [midea_ac_lan](https://github.com/georgezhao2010/midea_ac_lan) project for Home Assistant
 - The [midea-local](https://github.com/midea-lan/midea-local) project.
@@ -41,6 +37,12 @@ Currently supports the following devices:
 | Fan                   | FA  | [link](/docs/fa.md) |
 | Humidifier            | FD  | [link](/docs/fd.md) |
 
+### Getting Started
+
+1.  **Wi-Fi Connection**: Ensure your device is connected to your local network. If it's not, follow the [Wi-Fi Setup Guide](/docs/wifi-setup.md).
+2.  **Installation**: Install the plugin via Homebridge UI.
+3.  **Discovery**: Use the built-in discovery tool in the settings to find your devices and obtain security keys.
+
 ### Key Features (Air Conditioners)
 
 - **Comprehensive Mode Control**: Dedicated switches for Cool, Heat, Auto, Dry, Fan, and Self-cleaning modes.
@@ -61,12 +63,12 @@ If you have a device not supported by the plugin then useful information will be
 
 **Option 1: Install via Homebridge Config UI X:**
 
-Search for "midea" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-midea-platform`.
+Search for "portasplit" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `@jouskaio/homebridge-midea-portasplit`.
 
 **Option 2: Manually Install:**
 
 ```text
-sudo npm install -g homebridge-midea-platform
+sudo npm install -g @jouskaio/homebridge-midea-portasplit
 ```
 
 Midea device status is retrieved over your Local Area Network (LAN) and credentials are obtained from the Midea cloud services over the internet. While the plugin maintains a status cache, **use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges)** is strongly encouraged. As noted below in the _network resiliency_ section, this plugin will make multiple attempts to fulfill a request if necessary, which can take time.
@@ -85,7 +87,7 @@ This plugin is fully compatible with **Matter**, the unifying standard for smart
 
 - **Fan Speed**: For best compatibility with Google Home via Matter, set `fanSpeedMode` to `5 levels` (Silent, Low, Medium, High, Full + Auto) in the AC options.
 - **Child Bridge**: Matter works best when the plugin is running in a [Child Bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges).
-- **Dependencies**: If you see "Module not found" errors after an update, run `npm run setup-remote` again to update the dependencies on your server.
+- **Updates**: As this is an official npm package, updates can be handled directly via the Homebridge UI.
 
 ## Power & Energy Monitoring
 
@@ -158,7 +160,7 @@ If some accessories (like Humidity or Power consumption) do not appear on your m
 1.  **Check the "Climate" Status**: Apple Home often groups sensors (Temperature, Humidity) at the top of the Home tab under a single "Climate" icon. Tap it to see individual values.
 2.  **Make them "Favorites"**: To show a sensor as a separate tile on the main screen:
     - Long-press the accessory (e.g., the AC unit) -> **Accessory Details**.
-    - Scroll down to the list of services (Humidité, Température).
+    - Scroll down to the list of services (Humidity, Temperature).
     - Tap on the specific sensor -> **Accessory Details** (gear icon).
     - Ensure **Add to Favorites** is turned **ON**.
 3.  **Check "Show in Home View"**: In the same settings menu, ensure **Show in Home View** is enabled.
@@ -173,15 +175,6 @@ If some accessories (like Humidity or Power consumption) do not appear on your m
 [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x) is the easiest and **strongly recommended** way to configure this plugin.
 
 You should use the UI to discover and add devices. More information on the settings can be found in the [wiki](https://github.com/kovapatrik/homebridge-midea-platform/wiki#device-discovery).
-
-### Development & Remote Testing
-
-If you are developing this plugin and want to test it on a remote Homebridge server (e.g., on a Raspberry Pi/Proxmox on your LAN), you can use the built-in deployment scripts:
-
-1.  **Initial Setup**: Run `npm run setup-remote` to prepare your server (installs `rsync`, updates Node.js to v22, and installs dependencies).
-2.  **Fast Deploy**: Run `npm run deploy` to build the plugin, sync files to the server, and restart Homebridge automatically.
-
-_Note: Make sure to update the IP address and credentials in `package.json` before running these scripts._
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Currently supports the following devices:
 | Fan                   | FA  | [link](/docs/fa.md) |
 | Humidifier            | FD  | [link](/docs/fd.md) |
 
+### Key Features (Air Conditioners)
+
+- **Comprehensive Mode Control**: Dedicated switches for Cool, Heat, Auto, Dry, Fan, and Self-cleaning modes.
+- **Granular Fan Control**: Choose between continuous 0-100% control or specific steps (Low, Med, High, etc.). Full support for native HomeKit/Matter Auto fan mode.
+- **Power Management (Gear)**: Limit your AC's power consumption (25%, 50%, 75%, 100% or continuous 0-100% selector).
+- **Energy Monitoring**: Real-time power usage (Watts) and total energy consumption (kWh) with Eve Home compatibility.
+- **Advanced Comfort**: ION (Anion), iSense (Smart Eye), Eco, Boost, and Sleep modes.
+- **Smart Sensors**: Indoor humidity, outdoor temperature, and LED display control.
+- **Weather Fallback**: Use local weather data (OpenWeatherMap) as a fallback for indoor humidity if your device's physical sensor is broken.
+- **Automation Ready**: Built-in Off Timer (Valve service) to automatically shut down after a set duration. [See recipes](/docs/automations.md).
+- **Improved Compatibility**: Optimized for HomeKit (iOS), Google Home (Android), and Matter bridges.
+
 ### Unsupported Devices
 
 If you have a device not supported by the plugin then useful information will be logged as warnings. If you are interested in developing support for a device please contact the authors by opening an [issue](https://github.com/kovapatrik/homebridge-midea-platform/issues). Please attach the `lua` file to the issue, if possible. Here is the [guide](/docs/download_lua.md) on how to download the `lua` file.
@@ -57,7 +69,90 @@ Search for "midea" in [homebridge-config-ui-x](https://github.com/oznu/homebridg
 sudo npm install -g homebridge-midea-platform
 ```
 
-Midea device status is retrieved over your Local Area Network (LAN) and credentials are obtained from the Midea cloud services over the internet. While the plugin maintains a status cache, **use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges)** is strongly encouraged. As noted below in the _network resiliency_ section, this plugin will make multiple attempts to fulfill a request if necessary, which can take time.
+ Midea device status is retrieved over your Local Area Network (LAN) and credentials are obtained from the Midea cloud services over the internet. While the plugin maintains a status cache, **use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges)** is strongly encouraged. As noted below in the _network resiliency_ section, this plugin will make multiple attempts to fulfill a request if necessary, which can take time.
+
+## Matter & Multi-platform Compatibility
+
+This plugin is fully compatible with **Matter**, the unifying standard for smart homes. By exposing your Midea devices via a Matter bridge, you can control them across all major platforms including **Apple Home**, **Google Home**, **Amazon Alexa**, and **Samsung SmartThings**.
+
+### How to set up Matter
+1.  **Homebridge 2.0+**: Enable the native Matter bridge in your Homebridge settings.
+2.  **Homebridge 1.x**: Use a plugin like `homebridge-matter` or [Matterbridge](https://github.com/Luligu/matterbridge).
+3.  **Pairing**: Once enabled, Homebridge will provide a Matter setup code/QR. Pair this code with your preferred platform (e.g., Google Home app).
+
+### Tips for Matter
+- **Fan Speed**: For best compatibility with Google Home via Matter, set `fanSpeedMode` to `5 levels` (Silent, Low, Medium, High, Full + Auto) in the AC options.
+- **Child Bridge**: Matter works best when the plugin is running in a [Child Bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges).
+- **Dependencies**: If you see "Module not found" errors after an update, run `npm run setup-remote` again to update the dependencies on your server.
+
+## Power & Energy Monitoring
+
+This plugin provides real-time power (Watts) and total energy (kWh) monitoring.
+
+#### For Eve Home App (Recommended)
+The plugin automatically exposes standard energy characteristics that are natively visible in the **Eve Home** app. 
+- **History**: The plugin supports local data logging (via `fakegato-history`). This allows you to see consumption and climate graphs directly in the Eve app.
+- **Auto-Config**: No extra configuration is needed beyond enabling the `Power Meter` option in the device settings.
+
+#### For Homebridge UI (Web Dashboard)
+You can see real-time consumption directly in your browser:
+1.  Go to the **Accessories** tab in the Homebridge web interface.
+2.  Find your Air Conditioner.
+3.  Click on the tile to see all details, including **Electric Power (W)** and **Total Consumption (kWh)**.
+    *Note: History graphs are NOT displayed in the Homebridge UI accessories tab; they are exclusively for the Eve app.*
+
+#### For Apple Home App (Standard)
+Since Apple's Home app does not natively support power meters, the plugin uses a workaround by exposing values via other sensor types. You can configure this in the AC options:
+
+- **Power Display Type**: Choose how to show real-time Watts (e.g., as Lux, Humidity %, CO2 ppm, or Temperature °).
+- **Energy Display Type**: Choose how to show total energy kWh (e.g., as a separate Temperature or Humidity sensor).
+
+> [!TIP]
+> **To see the number on the dashboard**: 
+> - **Lux** and **Temperature** types show the value directly on the tile (e.g., "339 lx" or "339°"). 
+> - **CO2** type only shows "Normal" or "Detected" on the tile; you have to click to see the numeric value (ppm).
+> - **Humidity** is limited to 100%, so it's not recommended for power display.
+
+> [!IMPORTANT]
+> **Graphs in HomeKit**: Apple Home (HomeKit) does **not** natively support history graphs for third-party accessories. You can see the current value in the Home app, but to see historical graphs, you **must** use the **Eve Home** app. HomeKit does not allow "importing" these graphs from Eve.
+
+## Weather Service & Humidity Fallback
+
+If your Midea device has a broken humidity sensor (e.g., it always reports 0% or 255%), you can enable the **Weather Service** to provide local outdoor humidity as a proxy.
+
+1.  **API Key**: Obtain a free API key from [OpenWeatherMap](https://openweathermap.org/api). Note that it can take up to 2 hours for a new key to become active.
+2.  **Configuration**: Enable the Weather Service in the global plugin settings and enter your API key.
+3.  **Location**: By default, the plugin uses your server's IP address to determine your location. You can also manually specify `latitude,longitude` or a **City Name** in the settings.
+4.  **Enable Fallback**: In the specific device settings (AC or Dehumidifier), enable **Humidity Weather Fallback**.
+
+> [!NOTE]
+> If humidity still shows **0%** after configuration:
+> 1. Check the Homebridge logs for `[WeatherService]` updates.
+> 2. Ensure your API key is active (it can take up to 2 hours).
+> 3. **Per-Device Activation**: You must enable **Humidity Weather Fallback** in the *specific* settings of your Air Conditioner/Dehumidifier, not just globally.
+> 4. **Wait a few minutes**: The plugin will automatically update the display as soon as it receives the first weather data.
+
+## HomeKit Tips & Troubleshooting
+
+### "Accessory Not Certified" Message
+If you see a message saying "This accessory has not been certified to work with HomeKit", **this is normal**. Homebridge is an open-source project and is not officially certified by Apple.
+- **Does it affect functionality?** No. All features work exactly the same.
+- **Can it be removed?** No, as only official commercial hardware gets this certification. You can safely dismiss this warning.
+- **Is it the cause of missing sensors?** **No.** If your sensors are missing from the Home tab, it's an interface setting (see below), not a certification issue.
+
+### Accessories Missing from Home View
+If some accessories (like Humidity or Power consumption) do not appear on your main "Home" tab, they are likely just hidden or grouped by Apple Home:
+
+1.  **Check the "Climate" Status**: Apple Home often groups sensors (Temperature, Humidity) at the top of the Home tab under a single "Climate" icon. Tap it to see individual values.
+2.  **Make them "Favorites"**: To show a sensor as a separate tile on the main screen:
+    - Long-press the accessory (e.g., the AC unit) -> **Accessory Details**.
+    - Scroll down to the list of services (Humidité, Température).
+    - Tap on the specific sensor -> **Accessory Details** (gear icon).
+    - Ensure **Add to Favorites** is turned **ON**.
+3.  **Check "Show in Home View"**: In the same settings menu, ensure **Show in Home View** is enabled.
+
+> [!IMPORTANT]
+> When using a **child bridge**, you must pair the Midea platform separately in your Home app. The accessories will not appear if you only pair the main Homebridge bridge. Look for the QR code specifically for the "Midea Platform" in the Homebridge UI.
 
 ## Configuration
 
@@ -66,6 +161,15 @@ Midea device status is retrieved over your Local Area Network (LAN) and credenti
 [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x) is the easiest and **strongly recommended** way to configure this plugin.
 
 You should use the UI to discover and add devices. More information on the settings can be found in the [wiki](https://github.com/kovapatrik/homebridge-midea-platform/wiki#device-discovery).
+
+### Development & Remote Testing
+
+If you are developing this plugin and want to test it on a remote Homebridge server (e.g., on a Raspberry Pi/Proxmox on your LAN), you can use the built-in deployment scripts:
+
+1.  **Initial Setup**: Run `npm run setup-remote` to prepare your server (installs `rsync`, updates Node.js to v22, and installs dependencies).
+2.  **Fast Deploy**: Run `npm run deploy` to build the plugin, sync files to the server, and restart Homebridge automatically.
+
+*Note: Make sure to update the IP address and credentials in `package.json` before running these scripts.*
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -69,18 +69,20 @@ Search for "midea" in [homebridge-config-ui-x](https://github.com/oznu/homebridg
 sudo npm install -g homebridge-midea-platform
 ```
 
- Midea device status is retrieved over your Local Area Network (LAN) and credentials are obtained from the Midea cloud services over the internet. While the plugin maintains a status cache, **use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges)** is strongly encouraged. As noted below in the _network resiliency_ section, this plugin will make multiple attempts to fulfill a request if necessary, which can take time.
+Midea device status is retrieved over your Local Area Network (LAN) and credentials are obtained from the Midea cloud services over the internet. While the plugin maintains a status cache, **use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges)** is strongly encouraged. As noted below in the _network resiliency_ section, this plugin will make multiple attempts to fulfill a request if necessary, which can take time.
 
 ## Matter & Multi-platform Compatibility
 
 This plugin is fully compatible with **Matter**, the unifying standard for smart homes. By exposing your Midea devices via a Matter bridge, you can control them across all major platforms including **Apple Home**, **Google Home**, **Amazon Alexa**, and **Samsung SmartThings**.
 
 ### How to set up Matter
+
 1.  **Homebridge 2.0+**: Enable the native Matter bridge in your Homebridge settings.
 2.  **Homebridge 1.x**: Use a plugin like `homebridge-matter` or [Matterbridge](https://github.com/Luligu/matterbridge).
 3.  **Pairing**: Once enabled, Homebridge will provide a Matter setup code/QR. Pair this code with your preferred platform (e.g., Google Home app).
 
 ### Tips for Matter
+
 - **Fan Speed**: For best compatibility with Google Home via Matter, set `fanSpeedMode` to `5 levels` (Silent, Low, Medium, High, Full + Auto) in the AC options.
 - **Child Bridge**: Matter works best when the plugin is running in a [Child Bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges).
 - **Dependencies**: If you see "Module not found" errors after an update, run `npm run setup-remote` again to update the dependencies on your server.
@@ -90,26 +92,32 @@ This plugin is fully compatible with **Matter**, the unifying standard for smart
 This plugin provides real-time power (Watts) and total energy (kWh) monitoring.
 
 #### For Eve Home App (Recommended)
-The plugin automatically exposes standard energy characteristics that are natively visible in the **Eve Home** app. 
+
+The plugin automatically exposes standard energy characteristics that are natively visible in the **Eve Home** app.
+
 - **History**: The plugin supports local data logging (via `fakegato-history`). This allows you to see consumption and climate graphs directly in the Eve app.
 - **Auto-Config**: No extra configuration is needed beyond enabling the `Power Meter` option in the device settings.
 
 #### For Homebridge UI (Web Dashboard)
+
 You can see real-time consumption directly in your browser:
+
 1.  Go to the **Accessories** tab in the Homebridge web interface.
 2.  Find your Air Conditioner.
 3.  Click on the tile to see all details, including **Electric Power (W)** and **Total Consumption (kWh)**.
-    *Note: History graphs are NOT displayed in the Homebridge UI accessories tab; they are exclusively for the Eve app.*
+    _Note: History graphs are NOT displayed in the Homebridge UI accessories tab; they are exclusively for the Eve app._
 
 #### For Apple Home App (Standard)
+
 Since Apple's Home app does not natively support power meters, the plugin uses a workaround by exposing values via other sensor types. You can configure this in the AC options:
 
 - **Power Display Type**: Choose how to show real-time Watts (e.g., as Lux, Humidity %, CO2 ppm, or Temperature °).
 - **Energy Display Type**: Choose how to show total energy kWh (e.g., as a separate Temperature or Humidity sensor).
 
 > [!TIP]
-> **To see the number on the dashboard**: 
-> - **Lux** and **Temperature** types show the value directly on the tile (e.g., "339 lx" or "339°"). 
+> **To see the number on the dashboard**:
+>
+> - **Lux** and **Temperature** types show the value directly on the tile (e.g., "339 lx" or "339°").
 > - **CO2** type only shows "Normal" or "Detected" on the tile; you have to click to see the numeric value (ppm).
 > - **Humidity** is limited to 100%, so it's not recommended for power display.
 
@@ -127,20 +135,24 @@ If your Midea device has a broken humidity sensor (e.g., it always reports 0% or
 
 > [!NOTE]
 > If humidity still shows **0%** after configuration:
+>
 > 1. Check the Homebridge logs for `[WeatherService]` updates.
 > 2. Ensure your API key is active (it can take up to 2 hours).
-> 3. **Per-Device Activation**: You must enable **Humidity Weather Fallback** in the *specific* settings of your Air Conditioner/Dehumidifier, not just globally.
+> 3. **Per-Device Activation**: You must enable **Humidity Weather Fallback** in the _specific_ settings of your Air Conditioner/Dehumidifier, not just globally.
 > 4. **Wait a few minutes**: The plugin will automatically update the display as soon as it receives the first weather data.
 
 ## HomeKit Tips & Troubleshooting
 
 ### "Accessory Not Certified" Message
+
 If you see a message saying "This accessory has not been certified to work with HomeKit", **this is normal**. Homebridge is an open-source project and is not officially certified by Apple.
+
 - **Does it affect functionality?** No. All features work exactly the same.
 - **Can it be removed?** No, as only official commercial hardware gets this certification. You can safely dismiss this warning.
 - **Is it the cause of missing sensors?** **No.** If your sensors are missing from the Home tab, it's an interface setting (see below), not a certification issue.
 
 ### Accessories Missing from Home View
+
 If some accessories (like Humidity or Power consumption) do not appear on your main "Home" tab, they are likely just hidden or grouped by Apple Home:
 
 1.  **Check the "Climate" Status**: Apple Home often groups sensors (Temperature, Humidity) at the top of the Home tab under a single "Climate" icon. Tap it to see individual values.
@@ -169,7 +181,7 @@ If you are developing this plugin and want to test it on a remote Homebridge ser
 1.  **Initial Setup**: Run `npm run setup-remote` to prepare your server (installs `rsync`, updates Node.js to v22, and installs dependencies).
 2.  **Fast Deploy**: Run `npm run deploy` to build the plugin, sync files to the server, and restart Homebridge automatically.
 
-*Note: Make sure to update the IP address and credentials in `package.json` before running these scripts.*
+_Note: Make sure to update the IP address and credentials in `package.json` before running these scripts._
 
 ## Contribution
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -443,11 +443,15 @@
                 },
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "maxTemp": {
                   "title": "Maximum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "tempStep": {
                   "title": "Temperature Step (°C)",
@@ -632,11 +636,15 @@
               "properties": {
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "maxTemp": {
                   "title": "Maximum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "tempStep": {
                   "title": "Temperature Step (°C)",
@@ -686,11 +694,15 @@
               "properties": {
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "maxTemp": {
                   "title": "Maximum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "tempStep": {
                   "title": "Temperature Step (°C)",
@@ -739,11 +751,15 @@
                 },
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "maxTemp": {
                   "title": "Maximum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "tempStep": {
                   "title": "Temperature Step (°C)",
@@ -790,11 +806,15 @@
                 },
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "maxTemp": {
                   "title": "Maximum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "tempStep": {
                   "title": "Temperature Step (°C)",
@@ -828,11 +848,15 @@
                 },
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "maxTemp": {
                   "title": "Maximum Temperature (°C)",
-                  "type": "number"
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 40
                 },
                 "tempStep": {
                   "title": "Temperature Step (°C)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,10 +1,10 @@
 {
-  "pluginAlias": "midea-platform",
+  "pluginAlias": "Midea-platform",
   "pluginType": "platform",
   "customUi": true,
   "customUiPath": "./dist/homebridge-ui",
-  "headerDisplay": "This plugin is currently experimental and under development.  Please report [bugs](https://github.com/kovapatrik/homebridge-midea-platform/issues)",
-  "footerDisplay": "For help please see the [homepage](https://github.com/kovapatrik/homebridge-midea-platform)",
+  "headerDisplay": "Custom version of the Midea Platform plugin. Report issues at [GitHub](https://github.com/Jouskaio/homebridge-midea-platform/issues)",
+  "footerDisplay": "Based on the work of [kovapatrik](https://github.com/kovapatrik/homebridge-midea-platform). Forked by Jouskaio.",
   "singular": true,
   "schema": {
     "type": "object",
@@ -129,6 +129,11 @@
                   "title": "Log refresh status errors",
                   "type": "boolean",
                   "description": "If you see warning and errors which are related to the refresh status process you can suppress these messages by disabling this setting. (e.g.: `Does not supports the protocol...`)"
+                },
+                "refreshBeforeSet": {
+                  "title": "Refresh status before set",
+                  "type": "boolean",
+                  "description": "If enabled, the plugin will refresh the device status before sending any command. This is useful if the device status can be changed by other applications (e.g. Midea SmartHome) to avoid command conflicts."
                 }
               }
             },

--- a/config.schema.json
+++ b/config.schema.json
@@ -899,12 +899,7 @@
           "title": "Weather Service (Humidity Fallback)",
           "expandable": true,
           "expanded": false,
-          "items": [
-            "weather.enabled",
-            "weather.apiKey",
-            "weather.location",
-            "weather.interval"
-          ]
+          "items": ["weather.enabled", "weather.apiKey", "weather.location", "weather.interval"]
         },
         {
           "key": "devices",
@@ -938,11 +933,7 @@
                   "title": "Sensors",
                   "expandable": true,
                   "expanded": false,
-                  "items": [
-                    "devices[].A1_options.temperatureSensor",
-                    "devices[].A1_options.humiditySensor",
-                    "devices[].A1_options.humidityWeatherFallback"
-                  ]
+                  "items": ["devices[].A1_options.temperatureSensor", "devices[].A1_options.humiditySensor", "devices[].A1_options.humidityWeatherFallback"]
                 },
                 "devices[].A1_options.fanAccessory",
                 "devices[].A1_options.pumpSwitch",
@@ -964,11 +955,7 @@
                   "title": "Swing Options",
                   "expandable": true,
                   "expanded": false,
-                  "items": [
-                    "devices[].AC_options.swing.mode",
-                    "devices[].AC_options.swing.angleAccessory",
-                    "devices[].AC_options.swing.angleMainControl"
-                  ]
+                  "items": ["devices[].AC_options.swing.mode", "devices[].AC_options.swing.angleAccessory", "devices[].AC_options.swing.angleMainControl"]
                 },
                 {
                   "type": "fieldset",
@@ -1011,11 +998,7 @@
                   "title": "Display & Audio",
                   "expandable": true,
                   "expanded": false,
-                  "items": [
-                    "devices[].AC_options.displaySwitch",
-                    "devices[].AC_options.displaySwitchAlternate",
-                    "devices[].AC_options.audioFeedbackSwitch"
-                  ]
+                  "items": ["devices[].AC_options.displaySwitch", "devices[].AC_options.displaySwitchAlternate", "devices[].AC_options.audioFeedbackSwitch"]
                 },
                 {
                   "type": "fieldset",
@@ -1034,11 +1017,7 @@
                   "title": "Fan Settings",
                   "expandable": true,
                   "expanded": false,
-                  "items": [
-                    "devices[].AC_options.fanAccessory",
-                    "devices[].AC_options.fanAutoSwitch",
-                    "devices[].AC_options.fanSpeedMode"
-                  ]
+                  "items": ["devices[].AC_options.fanAccessory", "devices[].AC_options.fanAutoSwitch", "devices[].AC_options.fanSpeedMode"]
                 },
                 {
                   "type": "fieldset",

--- a/config.schema.json
+++ b/config.schema.json
@@ -28,6 +28,35 @@
         "type": "boolean",
         "description": "Debug data for the custom UI device discovery process will be logged to the Homebridge log and Javascript console."
       },
+      "weather": {
+        "title": "Weather Service (Humidity Fallback)",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "Enable Weather Service",
+            "type": "boolean",
+            "default": false,
+            "description": "Enables fetching local weather data to provide a humidity fallback when device sensors fail."
+          },
+          "apiKey": {
+            "title": "OpenWeatherMap API Key",
+            "type": "string",
+            "description": "Your OpenWeatherMap API key. You can get one for free at [https://openweathermap.org/api](https://openweathermap.org/api) (use the 'Current Weather Data' API)."
+          },
+          "location": {
+            "title": "Manual Location (Lat,Lon)",
+            "type": "string",
+            "description": "Manually specify location as 'latitude,longitude' (e.g. '48.8566,2.3522'). If left blank, location will be determined by server IP."
+          },
+          "interval": {
+            "title": "Update Interval (minutes)",
+            "type": "number",
+            "default": 30,
+            "minimum": 5,
+            "description": "How often to update weather data. Default is 30 minutes."
+          }
+        }
+      },
       "devices": {
         "type": "array",
         "items": {
@@ -122,7 +151,7 @@
                 },
                 "humiditySensor": {
                   "title": "Humidity Sensor",
-                  "description": "Toggles if a seperated humidity sensor is created with the accessory. This sensor can be used for automations as for some reason the internal humidity sensor is not usable for this.",
+                  "description": "Toggles if a separate humidity sensor is created. This sensor can be used for automations as for some reason the internal humidity sensor is not usable for this.",
                   "type": "boolean"
                 },
                 "pumpSwitch": {
@@ -160,6 +189,12 @@
                   "description": "Offset for the humidity sensor. This is useful if the humidity sensor is not accurate or if you want to adjust the humidity value.",
                   "type": "number",
                   "required": true
+                },
+                "humidityWeatherFallback": {
+                  "title": "Humidity Weather Fallback",
+                  "description": "Use local weather humidity if the device sensor reports 0% or is unavailable.",
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -196,6 +231,11 @@
                       "description": "Toggles if the swing angle accessory is created with the accessory. The accessory can be used to set the angle of the slat to a specified value. The `mode` property will be used to determine the direction of the slat. The main position bar will be used to set the angle of the direction which is selected in the `mode` property.",
                       "type": "boolean"
                     },
+                    "angleAccessoryName": {
+                      "title": "Swing Angle Accessory Name",
+                      "description": "Custom name for the swing angle accessory.",
+                      "type": "string"
+                    },
                     "angleMainControl": {
                       "title": "Swing Angle Main Control",
                       "description": "If `mode` property is Both and the swing angle accessory is enabled, this property will be used to determine which direction will be controlled by the main position bar of the accessory.",
@@ -215,75 +255,186 @@
                   "description": "Toggles if the outdoor temperature is created with the accessory.",
                   "type": "boolean"
                 },
-                "audioFeedback": {
-                  "title": "Audio Feedback",
-                  "description": "Toggles if the unit beeps when a command is sent.",
+                "outDoorTempName": {
+                  "title": "Outdoor Temperature Name",
+                  "description": "Custom name for the outdoor temperature sensor.",
+                  "type": "string"
+                },
+                "audioFeedbackSwitch": {
+                  "title": "Audio Feedback Switch",
+                  "description": "Toggles if the audio feedback switch is created with the accessory.",
                   "type": "boolean"
                 },
-                "screenOff": {
-                  "title": "Diplay screen off by default",
-                  "description": "Toggles if the screen is turned off by default when the unit is turned on.",
+                "audioFeedbackSwitchName": {
+                  "title": "Audio Feedback Switch Name",
+                  "description": "Custom name for the audio feedback switch.",
+                  "type": "string"
+                },
+                "smartEyeSwitch": {
+                  "title": "iSense (Smart Eye) Switch",
+                  "description": "Toggles if the iSense switch is created with the accessory.",
                   "type": "boolean"
+                },
+                "smartEyeSwitchName": {
+                  "title": "iSense Switch Name",
+                  "description": "Custom name for the iSense switch.",
+                  "type": "string"
+                },
+                "powerMeter": {
+                  "title": "Power Meter",
+                  "description": "Toggles if the power meter accessory is created with the accessory. This displays real-time power consumption and total energy usage.",
+                  "type": "boolean"
+                },
+                "powerMeterName": {
+                  "title": "Power Meter Name",
+                  "description": "Custom name for the power meter accessory.",
+                  "type": "string"
+                },
+                "powerDisplayType": {
+                  "title": "Power Display Type (Native App)",
+                  "description": "How real-time power (Watts) should be displayed in the standard Home app and Homebridge widgets. 'Lux' and 'Temperature' show the number directly. 'CO2' only shows 'Normal' on the main widget.",
+                  "type": "string",
+                  "default": "Lux",
+                  "oneOf": [
+                    { "title": "Lux (Shows number + 'lx')", "enum": ["Lux"] },
+                    { "title": "Temperature (Shows number + '°')", "enum": ["Temperature"] },
+                    { "title": "CO2 (Shows 'Normal', number hidden)", "enum": ["CarbonDioxide"] },
+                    { "title": "Humidity (Shows number + '%', max 100)", "enum": ["Humidity"] },
+                    { "title": "None (Hidden)", "enum": ["None"] }
+                  ]
+                },
+                "energyDisplayType": {
+                  "title": "Energy Display Type (Native App)",
+                  "description": "How total energy (kWh) should be displayed in the standard Home app and Homebridge widgets.",
+                  "type": "string",
+                  "default": "None",
+                  "oneOf": [
+                    { "title": "None (Hidden)", "enum": ["None"] },
+                    { "title": "Lux (Shows number + 'lx')", "enum": ["Lux"] },
+                    { "title": "Temperature (Shows number + '°')", "enum": ["Temperature"] },
+                    { "title": "CO2 (Shows 'Normal', number hidden)", "enum": ["CarbonDioxide"] },
+                    { "title": "Humidity (Shows number + '%', max 100)", "enum": ["Humidity"] }
+                  ]
+                },
+                "timerSwitch": {
+                  "title": "Off Timer Switch",
+                  "description": "Toggles if the off timer switch is created with the accessory.",
+                  "type": "boolean"
+                },
+                "timerSwitchName": {
+                  "title": "Off Timer Switch Name",
+                  "description": "Custom name for the off timer switch.",
+                  "type": "string"
                 },
                 "ecoSwitch": {
                   "title": "Eco Mode Switch",
                   "description": "Toggles if the ECO mode switch is created with the accessory.",
                   "type": "boolean"
                 },
+                "ecoSwitchName": {
+                  "title": "Eco Mode Switch Name",
+                  "description": "Custom name for the ECO mode switch.",
+                  "type": "string"
+                },
                 "dryModeSwitch": {
-                  "title": "Dry Mode Switch",
+                  "title": "Mode: Dry Switch",
                   "description": "Toggles if the dry mode switch is created with the accessory.",
                   "type": "boolean"
+                },
+                "dryModeSwitchName": {
+                  "title": "Mode: Dry Switch Name",
+                  "description": "Custom name for the dry mode switch.",
+                  "type": "string"
                 },
                 "boostModeSwitch": {
                   "title": "Boost/Turbo Mode Switch",
                   "description": "Toggles if the boost/turbo mode switch is created with the accessory.",
                   "type": "boolean"
                 },
+                "boostModeSwitchName": {
+                  "title": "Boost/Turbo Mode Switch Name",
+                  "description": "Custom name for the boost/turbo mode switch.",
+                  "type": "string"
+                },
                 "breezeAwaySwitch": {
                   "title": "Breeze Away Mode",
                   "description": "Toggles if the breeze away mode swtich is created with the accessory.",
                   "type": "boolean"
                 },
+                "breezeAwaySwitchName": {
+                  "title": "Breeze Away Mode Switch Name",
+                  "description": "Custom name for the breeze away mode switch.",
+                  "type": "string"
+                },
                 "displaySwitch": {
-                  "type": "object",
-                  "properties": {
-                    "flag": {
-                      "title": "Display Switch",
-                      "description": "Toggles if a switch, which can turn the display on or off will be created or not.",
-                      "type": "boolean"
-                    },
-                    "command": {
-                      "title": "Display Switch Alternate Command",
-                      "description": "Use this if the switch display command does not work. If it doesn't work either way then you unit does not support this feature.",
-                      "type": "boolean"
-                    }
-                  }
+                  "title": "Display Switch",
+                  "description": "Toggles if a switch, which can turn the display on or off will be created or not.",
+                  "type": "boolean"
+                },
+                "displaySwitchAlternate": {
+                  "title": "Display Switch Alternate Command",
+                  "description": "Use this if the switch display command does not work. If it doesn't work either way then you unit does not support this feature.",
+                  "type": "boolean"
+                },
+                "displaySwitchName": {
+                  "title": "Display Switch Name",
+                  "description": "Custom name for the display switch.",
+                  "type": "string"
                 },
                 "auxHeatingSwitches": {
                   "title": "Auxiliary Heating Switches",
                   "description": "Toggles if the aux and aux+heat switches are created with the accessory.",
                   "type": "boolean"
                 },
+                "auxHeatingSwitchesName": {
+                  "title": "Auxiliary Heating Switch Name",
+                  "description": "Custom name for the auxiliary heating switch.",
+                  "type": "string"
+                },
+                "auxHeatingSwitchesPlusHeatName": {
+                  "title": "Auxiliary Heating + Heat Switch Name",
+                  "description": "Custom name for the auxiliary heating + heat switch.",
+                  "type": "string"
+                },
                 "selfCleanSwitch": {
-                  "title": "Self-cleaning Switch",
+                  "title": "Mode: Auto Clean Switch",
                   "description": "Toggles if the self-cleaning switch is created with the accessory.",
                   "type": "boolean"
+                },
+                "selfCleanSwitchName": {
+                  "title": "Mode: Auto Clean Switch Name",
+                  "description": "Custom name for the self-cleaning switch.",
+                  "type": "string"
                 },
                 "ionSwitch": {
                   "title": "ION Switch",
                   "description": "Toggles if the ION switch is created with the accessory.",
                   "type": "boolean"
                 },
+                "ionSwitchName": {
+                  "title": "ION Switch Name",
+                  "description": "Custom name for the ION switch.",
+                  "type": "string"
+                },
                 "outSilentSwitch": {
                   "title": "Out Silent Mode switch",
                   "description": "Toggles if the Out Silent Mode switch is created with the accessory. This mode reduces the outdoor unit noise by about 6dB.",
                   "type": "boolean"
                 },
+                "outSilentSwitchName": {
+                  "title": "Out Silent Mode Switch Name",
+                  "description": "Custom name for the outdoor silent mode switch.",
+                  "type": "string"
+                },
                 "rateSelector": {
                   "title": "Gear / Rate Selector",
                   "description": "Toggles if the gear / rate selector is created with the accessory.",
                   "type": "boolean"
+                },
+                "rateSelectorName": {
+                  "title": "Gear / Rate Selector Name",
+                  "description": "Custom name for the gear / rate selector.",
+                  "type": "string"
                 },
                 "minTemp": {
                   "title": "Minimum Temperature (°C)",
@@ -305,39 +456,121 @@
                   "type": "boolean"
                 },
                 "fanOnlyModeSwitch": {
-                  "title": "Fan Only Mode Switch",
+                  "title": "Mode: Fan Switch",
                   "description": "Toggles if the fan only mode switch is created with the accessory.",
                   "type": "boolean"
+                },
+                "fanOnlyModeSwitchName": {
+                  "title": "Mode: Fan Switch Name",
+                  "description": "Custom name for the fan only mode switch.",
+                  "type": "string"
                 },
                 "fanAccessory": {
                   "title": "Fan Accessory",
                   "description": "Toggles if the fan accessory is created with the accessory.",
                   "type": "boolean"
                 },
+                "fanAccessoryName": {
+                  "title": "Fan Accessory Name",
+                  "description": "Custom name for the fan accessory.",
+                  "type": "string"
+                },
+                "fanSpeedMode": {
+                  "title": "Fan Speed Mode",
+                  "description": "Choose between a continuous slider (None) or discrete speed steps (3 or 5 levels).",
+                  "type": "string",
+                  "default": "None",
+                  "oneOf": [
+                    { "title": "None (Continuous Slider)", "enum": ["None"] },
+                    { "title": "3 Levels (Low, Medium, High)", "enum": ["3"] },
+                    { "title": "5 Levels (Silent, Low, Medium, High, Full)", "enum": ["5"] }
+                  ]
+                },
                 "fanAutoSwitch": {
                   "title": "Fan Auto Switch",
                   "description": "Toggles if the fan auto switch is created with the accessory.",
                   "type": "boolean"
+                },
+                "fanAutoSwitchName": {
+                  "title": "Fan Auto Switch Name",
+                  "description": "Custom name for the fan auto switch.",
+                  "type": "string"
+                },
+                "coolModeSwitch": {
+                  "title": "Mode: Cool Switch",
+                  "description": "Toggles if the cool mode switch is created with the accessory.",
+                  "type": "boolean"
+                },
+                "coolModeSwitchName": {
+                  "title": "Mode: Cool Switch Name",
+                  "description": "Custom name for the cool mode switch.",
+                  "type": "string"
+                },
+                "heatModeSwitch": {
+                  "title": "Mode: Heat Switch",
+                  "description": "Toggles if the heat mode switch is created with the accessory.",
+                  "type": "boolean"
+                },
+                "heatModeSwitchName": {
+                  "title": "Mode: Heat Switch Name",
+                  "description": "Custom name for the heat mode switch.",
+                  "type": "string"
+                },
+                "autoModeSwitch": {
+                  "title": "Mode: Auto Switch",
+                  "description": "Toggles if the auto mode switch is created with the accessory.",
+                  "type": "boolean"
+                },
+                "autoModeSwitchName": {
+                  "title": "Mode: Auto Switch Name",
+                  "description": "Custom name for the auto mode switch.",
+                  "type": "string"
                 },
                 "sleepModeSwitch": {
                   "title": "Sleep Mode Switch",
                   "description": "Toggles if the sleep mode switch is created with the accessory.",
                   "type": "boolean"
                 },
+                "sleepModeSwitchName": {
+                  "title": "Sleep Mode Switch Name",
+                  "description": "Custom name for the sleep mode switch.",
+                  "type": "string"
+                },
                 "comfortModeSwitch": {
                   "title": "Comfort Mode Switch",
                   "description": "Toggles if the comfort mode switch is created with the accessory.",
                   "type": "boolean"
+                },
+                "comfortModeSwitchName": {
+                  "title": "Comfort Mode Switch Name",
+                  "description": "Custom name for the comfort mode switch.",
+                  "type": "string"
                 },
                 "temperatureSensor": {
                   "title": "Indoor Temperature Sensor",
                   "description": "Toggles if a seperated indoor temperature is created with the accessory. This sensor can be used for automations as for some reason the internal sensors are not usable for this.",
                   "type": "boolean"
                 },
+                "temperatureSensorName": {
+                  "title": "Indoor Temperature Sensor Name",
+                  "description": "Custom name for the indoor temperature sensor.",
+                  "type": "string"
+                },
                 "humiditySensor": {
                   "title": "Humidity Sensor",
-                  "description": "Toggles if a separate humidity sensor is created with the accessory. This sensor can be used for automations.",
+                  "description": "Toggles if a separate humidity sensor is created. Required to see indoor humidity in HomeKit.",
                   "type": "boolean"
+                },
+                "humiditySensorName": {
+                  "title": "Humidity Sensor Name",
+                  "description": "Custom name for the humidity sensor.",
+                  "type": "string"
+                },
+                "humidityWeatherFallback": {
+                  "title": "Humidity Weather Fallback",
+                  "description": "Use local weather humidity if the device sensor reports 0% or is unavailable.",
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -662,6 +895,18 @@
           "items": ["refreshInterval", "heartbeatInterval", "uiDebug"]
         },
         {
+          "type": "fieldset",
+          "title": "Weather Service (Humidity Fallback)",
+          "expandable": true,
+          "expanded": false,
+          "items": [
+            "weather.enabled",
+            "weather.apiKey",
+            "weather.location",
+            "weather.interval"
+          ]
+        },
+        {
           "key": "devices",
           "type": "tabarray",
           "title": "{{ value.name || 'new device' }}",
@@ -688,9 +933,18 @@
               "expandable": true,
               "expanded": false,
               "items": [
-                "devices[].A1_options.temperatureSensor",
+                {
+                  "type": "fieldset",
+                  "title": "Sensors",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].A1_options.temperatureSensor",
+                    "devices[].A1_options.humiditySensor",
+                    "devices[].A1_options.humidityWeatherFallback"
+                  ]
+                },
                 "devices[].A1_options.fanAccessory",
-                "devices[].A1_options.humiditySensor",
                 "devices[].A1_options.pumpSwitch",
                 "devices[].A1_options.waterTankSensor",
                 "devices[].A1_options.minHumidity",
@@ -706,37 +960,99 @@
               "items": [
                 "devices[].AC_options.serviceType",
                 {
-                  "key": "devices[].AC_options.swing",
-                  "items": ["devices[].AC_options.swing.mode", "devices[].AC_options.swing.angleAccessory", "devices[].AC_options.swing.angleMainControl"]
+                  "type": "fieldset",
+                  "title": "Swing Options",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.swing.mode",
+                    "devices[].AC_options.swing.angleAccessory",
+                    "devices[].AC_options.swing.angleMainControl"
+                  ]
                 },
-                "devices[].AC_options.heatingCapable",
-                "devices[].AC_options.outDoorTemp",
-                "devices[].AC_options.audioFeedback",
-                "devices[].AC_options.screenOff",
-                "devices[].AC_options.ecoSwitch",
-                "devices[].AC_options.breezeAwaySwitch",
-                "devices[].AC_options.dryModeSwitch",
-                "devices[].AC_options.boostModeSwitch",
-                "devices[].AC_options.auxHeatingSwitches",
-                "devices[].AC_options.selfCleanSwitch",
-                "devices[].AC_options.ionSwitch",
-                "devices[].AC_options.outSilentSwitch",
-                "devices[].AC_options.rateSelector",
                 {
-                  "key": "devices[].AC_options.displaySwitch",
-                  "items": ["devices[].AC_options.displaySwitch.flag", "devices[].AC_options.displaySwitch.command"]
+                  "type": "fieldset",
+                  "title": "Mode Switches",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.coolModeSwitch",
+                    "devices[].AC_options.heatModeSwitch",
+                    "devices[].AC_options.autoModeSwitch",
+                    "devices[].AC_options.dryModeSwitch",
+                    "devices[].AC_options.fanOnlyModeSwitch",
+                    "devices[].AC_options.selfCleanSwitch"
+                  ]
                 },
-                "devices[].AC_options.minTemp",
-                "devices[].AC_options.maxTemp",
-                "devices[].AC_options.tempStep",
-                "devices[].AC_options.fahrenheit",
-                "devices[].AC_options.fanOnlyModeSwitch",
-                "devices[].AC_options.fanAccessory",
-                "devices[].AC_options.fanAutoSwitch",
-                "devices[].AC_options.sleepModeSwitch",
-                "devices[].AC_options.comfortModeSwitch",
-                "devices[].AC_options.temperatureSensor",
-                "devices[].AC_options.humiditySensor"
+                {
+                  "type": "fieldset",
+                  "title": "Advanced Features",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.ecoSwitch",
+                    "devices[].AC_options.boostModeSwitch",
+                    "devices[].AC_options.ionSwitch",
+                    "devices[].AC_options.breezeAwaySwitch",
+                    "devices[].AC_options.outSilentSwitch",
+                    "devices[].AC_options.rateSelector",
+                    "devices[].AC_options.smartEyeSwitch",
+                    "devices[].AC_options.powerMeter",
+                    "devices[].AC_options.powerDisplayType",
+                    "devices[].AC_options.energyDisplayType",
+                    "devices[].AC_options.timerSwitch",
+                    "devices[].AC_options.sleepModeSwitch",
+                    "devices[].AC_options.comfortModeSwitch",
+                    "devices[].AC_options.auxHeatingSwitches"
+                  ]
+                },
+                {
+                  "type": "fieldset",
+                  "title": "Display & Audio",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.displaySwitch",
+                    "devices[].AC_options.displaySwitchAlternate",
+                    "devices[].AC_options.audioFeedbackSwitch"
+                  ]
+                },
+                {
+                  "type": "fieldset",
+                  "title": "Sensors",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.outDoorTemp",
+                    "devices[].AC_options.temperatureSensor",
+                    "devices[].AC_options.humiditySensor",
+                    "devices[].AC_options.humidityWeatherFallback"
+                  ]
+                },
+                {
+                  "type": "fieldset",
+                  "title": "Fan Settings",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.fanAccessory",
+                    "devices[].AC_options.fanAutoSwitch",
+                    "devices[].AC_options.fanSpeedMode"
+                  ]
+                },
+                {
+                  "type": "fieldset",
+                  "title": "Thresholds & Unit",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "devices[].AC_options.minTemp",
+                    "devices[].AC_options.maxTemp",
+                    "devices[].AC_options.tempStep",
+                    "devices[].AC_options.fahrenheit",
+                    "devices[].AC_options.heatingCapable"
+                  ]
+                }
               ]
             },
             {

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,5 +1,5 @@
 {
-  "pluginAlias": "Midea-platform",
+  "pluginAlias": "midea-portasplit",
   "pluginType": "platform",
   "customUi": true,
   "customUiPath": "./dist/homebridge-ui",

--- a/docs/a1.md
+++ b/docs/a1.md
@@ -11,7 +11,8 @@ Providing dehumidifier settings is optional and the whole section or individual 
     "waterTankSensor": "None",
     "minHumidity": 35,
     "maxHumidity": 85,
-    "humidityStep": 5
+    "humidityStep": 5,
+    "humidityWeatherFallback": false
 }
 ```
 
@@ -25,3 +26,4 @@ Providing dehumidifier settings is optional and the whole section or individual 
 - **minHumidity** _(optional)_: The minimum relative humidity that the unit can be set for. Default is 35%
 - **maxHumidity** _(optional)_: The maximum relative humidity that the unit can be set for. Default is 85%
 - **humidityStep** _(optional)_: Increment in which the relative himidity setting can be changed, may be set to either 5% or 10%. The default is 5%.
+- **humidityWeatherFallback** _(optional)_: If enabled, the plugin will use local weather data as a fallback for the humidity sensor if the device sensor is unavailable or reporting 0%. Requires the global **Weather Service** to be configured. Default is `false`.

--- a/docs/ac.md
+++ b/docs/ac.md
@@ -23,28 +23,36 @@ Providing air conditioner settings is optional and the whole section or individu
     },
     "heatingCapable": true,
     "outDoorTemp": false,
+    "humiditySensor": false,
+    "humidityWeatherFallback": false,
     "audioFeedback": false,
-    "screenOff": false,
-    "ecoSwitch": false,
+    "audioFeedbackSwitch": false,
+    "coolModeSwitch": false,
+    "heatModeSwitch": false,
+    "autoModeSwitch": false,
     "dryModeSwitch": false,
+    "fanOnlyModeSwitch": false,
+    "selfCleanSwitch": false,
+    "ecoSwitch": false,
     "boostModeSwitch": false,
     "breezeAwaySwitch": false,
-    "displaySwitch": {
-        "flag": true,
-        "command": false
-    },
+    "displaySwitch": false,
+    "displaySwitchAlternate": false,
     "auxHeatingSwitches": false,
-    "selfCleanSwitch": false,
     "ionSwitch": false,
+    "smartEyeSwitch": false,
+    "powerMeter": false,
+    "powerMeterName": "Consumption",
+    "powerDisplayType": "Lux",
+    "energyDisplayType": "None",
+    "timerSwitch": false,
     "rateSelector": false,
+    "sleepModeSwitch": false,
+    "fanSpeedMode": "None",
     "minTemp": 16,
     "maxTemp": 30,
     "tempStep": 1,
-    "fahrenheit": false,
-    "fanOnlyModeSwitch": false,
-    "fanAccessory": false,
-    "sleepModeSwitch": false,
-    "sleepModeAccessory": false
+    "fahrenheit": false
 }
 ```
 
@@ -56,23 +64,36 @@ Providing air conditioner settings is optional and the whole section or individu
   - **angleMainControl** _(optional)_: If `mode` property is Both and the swing angle accessory is enabled, this property will be used to determine which direction will be controlled by the main position bar of the accessory. Default is `Vertical`.
 - **heatingCapable** _(optional)_: Toggles if the unit is capable of heating. Default is `true`.
 - **outDoorTemp** _(optional)_: Toggles if the outdoor temperature sensor is created with the accessory. Default is `false`.
+- **humiditySensor** _(optional)_: Toggles if the indoor humidity sensor is created as a separate service. Required to see indoor humidity in HomeKit. Default is `false`.
+- **humidityWeatherFallback** _(optional)_: If enabled, the plugin will use local weather data as a fallback for the humidity sensor if the device sensor is unavailable or reporting 0%. Requires the global **Weather Service** to be configured. Default is `false`.
 - **audioFeedback** _(optional)_: Toggles if the unit beeps when a command is sent, default is false.
-- **screenOff** _(optional)_: Toggles if the screen is turned off by default when the unit is turned on. Default is `false`.
+- **audioFeedbackSwitch** _(optional)_: Toggles if the audio feedback switch is created with the accessory. Default is `false`.
+- **coolModeSwitch** _(optional)_: Toggles if a dedicated switch for Cool mode is created. Default is `false`.
+- **heatModeSwitch** _(optional)_: Toggles if a dedicated switch for Heat mode is created. Default is `false`.
+- **autoModeSwitch** _(optional)_: Toggles if a dedicated switch for Auto mode is created. Default is `false`.
+- **dryModeSwitch** _(optional)_: Toggles if a dedicated switch for Dry mode is created. Default is `false`.
+- **fanOnlyModeSwitch** _(optional)_: Toggles if a dedicated switch for Fan-only mode is created. Default is `false`.
+- **selfCleanSwitch** _(optional)_: Toggles if a dedicated switch for Self-cleaning (Auto-clean) mode is created. Default is `false`.
 - **ecoSwitch** _(optional)_: Toggles if the eco switch is created with the accessory. Default is `false`.
-- **dryModeSwitch** _(optional)_: Toggles if the dry mode switch is created with the accessory. Default is `false`.
 - **boostModeSwitch** _(optional)_: Toggles if the boost/turbo mode switch is created with the accessory. Default is `false`.
 - **breezeAwaySwitch** _(optional)_: Toggles if the breeze away switch is created with the accessory. Default is `false`.
-- **displaySwitch**:
-  - **flag** _(optional)_: Toggles if a switch, which can turn the display on or off will be created or not. Default is `true`.
-  - **command** _(optional)_: Use this if the switch display command does not work. If it doesn't work either way then you unit does not support this feature. Default is `false`.
+- **displaySwitch** _(optional)_: Toggles if a switch to turn the unit's display LED on or off is created. Default is `false`.
+- **displaySwitchAlternate** _(optional)_: Use this if the standard display switch does not work. Default is `false`.
 - **auxHeatingSwitches** _(optional)_: Toggles if the aux heating switches are created with the accessory. Default is `false`.
-- **selfCleanSwitch** _(optional)_: Toggles if the self-cleaning switch is created with the accessory. Default is `false`.
-- **ionSwitch** _(optional)_: Toggles if the ION switch is created with the accessory. Default is `false`.
-- **rateSelector** _(optional)_: Toggles if the gear selector is created with the accessory. Default is `false`.
-- **minTemp** _(optional)_: The minimum temperature that the unit can be set for. Default is `16 celsius`
-- **maxTemp** _(optional)_: The maximum temperature that the unit can be set for. Default is `30 celsius`
-- **tempStep** _(optional)_: Increment in which the temperature setting can be changed, may be set to either 0.5 or 1 degree celsius. The default is `1 degree`.
-- **fahrenheit** _(optional)_: Toggles if the temperature on the unit is displayed in Fahrenheit or Celsius. Default is `false` (displays in Celsius).
-- **fanOnlyModeSwitch** _(optional)_: Toggles if the fan only mode switch is created with the accessory. Default is `false`.
-- **fanAccessory** _(optional)_: Toggles if the fan accessory is created with the accessory. Default is `false`.
-- **sleepModeSwitch** _(optional)_: Toggles if the sleep mode switch is created with the accessory. Default is `false`.
+- **ionSwitch** _(optional)_: Toggles if the ION (Anion) switch is created with the accessory. Default is `false`.
+- **smartEyeSwitch** _(optional)_: Toggles if the iSense (Smart Eye) switch is created with the accessory. Default is `false`.
+- **powerMeter** _(optional)_: Toggles if the power meter accessory is created. This displays real-time power consumption (in Watts) and total energy usage (in kWh). Compatible with Eve Home. Default is `false`.
+- **powerMeterName** _(optional)_: Custom name for the power meter accessory.
+- **powerDisplayType** _(optional)_: How real-time power (Watts) should be displayed in the standard Home app. Options: `Lux` (default), `Humidity`, `CarbonDioxide`, `Temperature`, `None`. **Tip**: Use `CarbonDioxide` to show values without the "Lux" unit and avoid being capped at 100.
+- **energyDisplayType** _(optional)_: How total energy (kWh) should be displayed in the standard Home app. Options: `None` (default), `Lux`, `Humidity`, `CarbonDioxide`, `Temperature`.
+- **timerSwitch** _(optional)_: Toggles if the off timer switch is created (displayed as a Valve). Default is `false`.
+- **rateSelector** _(optional)_: Toggles if the gear selector (power consumption limit) is created. Allows setting 0-100% power limit. Default is `false`.
+- **sleepModeSwitch** _(optional)_: Toggles if the sleep mode switch is created. Default is `false`.
+- **fanSpeedMode** _(optional)_: Configure how fan speed is controlled.
+  - `None`: Continuous slider (0-100%).
+  - `3 levels`: Steps (Low, Medium, High).
+  - `5 levels`: Steps (Silent, Low, Medium, High, Full) + Auto.
+- **minTemp** _(optional)_: The minimum temperature that the unit can be set for. Default is `16 celsius`.
+- **maxTemp** _(optional)_: The maximum temperature that the unit can be set for. Default is `30 celsius`.
+- **tempStep** _(optional)_: Increment in which the temperature setting can be changed (0.5 or 1). Default is `1`.
+- **fahrenheit** _(optional)_: Toggles if the temperature is displayed in Fahrenheit or Celsius. Default is `false`.

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,0 +1,186 @@
+# Automation Recipes
+
+This guide provides examples of how to use the various switches and sensors provided by `homebridge-midea-platform` to create powerful automations in HomeKit (Apple Home app) or other HomeKit controllers.
+
+## Prerequisites
+
+To follow some of these examples, you might need additional plugins:
+- [homebridge-delay-switch](https://www.npmjs.com/package/homebridge-delay-switch): For timers with triggers.
+- [homebridge-dummy-legacy](https://www.npmjs.com/package/homebridge-dummy-legacy): For state persistence or virtual triggers (preferred version).
+
+> [!NOTE]
+> If you are using a **Child Bridge** for the Midea platform (recommended), you must pair it separately in HomeKit using its own QR code from the Homebridge UI.
+
+### Configuration Example for `homebridge-dummy-legacy`
+Unlike some other plugins, this one must be added to the **`accessories`** section of your `config.json`:
+```json
+{
+    "accessory": "DummySwitch",
+    "name": "AC Cool Mode Active"
+}
+```
+
+## Scenario 1: Built-in Off Timer
+
+The plugin includes a built-in timer that doesn't require extra plugins.
+
+### Configuration
+Ensure `"timerSwitch": true` is set in your `AC_options`.
+
+### How it works
+1. In HomeKit, you will see a **Valve** accessory named "Timer".
+2. Open its settings to set a "Duration" (e.g., 1 hour).
+3. When you turn on this "Timer", the AC will automatically turn off when the duration expires.
+
+### Automation
+- **Trigger**: When AC is turned on.
+- **Action**: Turn on the "Timer".
+- **Result**: Your AC will always turn off automatically after the set duration.
+
+## Scenario 2: Advanced Auto-off (with Delay Switch)
+
+If you want more control, like turning off the AC only if it's still running after a certain delay.
+
+### Configuration (`homebridge-delay-switch`)
+```json
+{
+    "accessory": "DelaySwitch",
+    "name": "AC Timeout",
+    "delay": 7200000,
+    "startOnReboot": false
+}
+```
+
+### Automations
+1. **Start Timer**: When Midea AC Power is turned ON -> Turn ON "AC Timeout".
+2. **Reset Timer**: When Midea AC Power is turned OFF -> Turn OFF "AC Timeout".
+3. **Execution**: When "AC Timeout" Motion Sensor detects motion (triggered when timer expires) -> Turn OFF Midea AC.
+
+## Scenario 3: Mold Prevention (Dry after Cool)
+
+Running the fan for a few minutes after using the AC in cooling mode helps dry the internal components and prevents mold growth.
+
+### Prerequisites
+- Enable `"fanOnlyModeSwitch": true` in `AC_options`.
+- A `DelaySwitch` set to 600000 ms (10 minutes).
+
+### Automations
+1. **State Tracking**: 
+    - When the AC changes to **Cool** mode -> Turn ON "AC Cool Mode Active" (Dummy Switch).
+    - When the AC changes to a mode other than Cool -> Turn OFF "AC Cool Mode Active".
+2. **Trigger**: When Midea AC is turned OFF (**Power OFF**).
+3. **Condition**: If "AC Cool Mode Active" is **ON**.
+4. **Action**: 
+    - Activate "Midea AC Fan Only".
+    - Activate "Dry Timer" (Delay Switch).
+5. **Cleanup**: When "Dry Timer" Motion Sensor detects motion (end of delay) -> Turn OFF "Midea AC Fan Only".
+
+## Scenario 4: Night Mode
+
+Turn off the noisy features and bright LED when it's time to sleep.
+
+### Prerequisites
+- Enable `"sleepModeSwitch": true`, `"displaySwitch": true`, and `"outSilentSwitch": true`.
+
+### Automation
+- **Trigger**: At 10:00 PM.
+- **Condition**: If Midea AC is ON.
+- **Action**:
+    - Turn ON "Midea AC Sleep Mode".
+    - Turn OFF "Midea AC Display".
+    - Turn ON "Midea AC Outdoor Silent".
+
+## Scenario 5: Temperature-Based Automation
+
+Turn on the AC when it gets too hot, but only if someone is home.
+
+### Automation
+- **Trigger**: When Midea AC Temperature Sensor rises above 25°C.
+- **Condition**: If anyone is at home.
+- **Action**: Turn ON Midea AC (Cool mode, 22°C).
+
+---
+
+## Tip: Complex Automations without Eve (HomeKit Shortcuts)
+
+If the Home app seems limited for conditions (e.g., "only IF the AC is on"), you can use the built-in **Shortcuts**:
+1. Create a new automation in the Home app.
+2. Choose your trigger (e.g., "A specific time of day").
+3. On the accessory selection screen, scroll to the bottom and tap **"Convert to Shortcut"**.
+4. You can now add an **"If"** block to check the status of a device before executing the action.
+
+---
+
+## Scenario 6: Maintaining Comfort (Heat / Cool)
+
+Keep the room at an ideal temperature automatically.
+
+### Cool Mode (Summer)
+- **Trigger**: Indoor temperature rises above 25°C.
+- **Action**: Set AC to **Cool** mode at 21°C.
+
+### Heat Mode (Winter)
+- **Trigger**: Indoor temperature falls below 19°C.
+- **Action**: Set AC to **Heat** mode at 21°C.
+
+*Note: The Home app allows setting these thresholds natively. If you want this to trigger only when you are home, use the "People" option in the automation settings.*
+
+## Scenario 7: Auto-Cleaning (Self Clean)
+
+Start cleaning when the device requests it or periodically.
+
+### Based on device status
+- **Prerequisites**: Enable `"selfCleanSwitch": true` in `AC_options`.
+- **Trigger**: When the AC's "Filter Change Indication" changes to "Change Filter".
+- **Action**: Activate the "Midea AC Self Clean" switch.
+
+### Periodic (Monthly)
+- **Trigger**: Once a month on Sunday at 10 AM.
+- **Action**: Activate "Midea AC Self Clean".
+
+## Scenario 8: Night Eco Mode
+
+Save energy at night without sacrificing comfort.
+
+### Automation (Without Eve)
+- **Trigger**: At 11:00 PM.
+- **Action**: **Convert to Shortcut** (at the bottom of the list).
+- **Shortcut Logic**:
+    1. Add the **"Control [My Home]"** action -> Select the AC -> Get the status of "Power".
+    2. Add an **"If"** block -> If "Power" is equal to "Yes" (On).
+    3. In the "If": Add the **"Control [My Home]"** action -> Turn ON "Midea AC Eco Mode".
+- **Cancellation**: Create a simple inverse rule at 7:00 AM to turn off Eco mode.
+
+## Scenario 9: Dehumidification Mode (Dry)
+
+Fight excessive humidity.
+
+### Automation
+- **Prerequisites**: Enable `"dryModeSwitch": true` and `"humiditySensor": true` in `AC_options`.
+- **Trigger**: When indoor humidity rises above 65% (Humidity Sensor).
+- **Action**: Activate the "Midea AC Dry Mode" switch.
+
+---
+
+## Pro-Tip: Hiding Virtual Accessories
+
+To keep your Home app clean, you can hide the virtual switches (`DelaySwitch`, `DummySwitch`) that are only used for automations.
+
+1. In the **Apple Home** app, long-press the accessory tile.
+2. Tap **Accessory Details** (or the gear icon).
+3. **Include in Home Summaries**: Turn this **OFF**. This prevents the switch from appearing in the status icons at the top of the Home tab (e.g., "1 Switch On").
+4. **Show in Home View**: Turn this **OFF**. This removes the tile from your main "Home" tab. The accessory will still be visible inside its specific Room tab.
+5. **Add to Favorites**: Turn this **OFF** to remove it from the Control Center.
+
+The accessories will continue to work perfectly in your automations even when hidden.
+
+### How to Find Hidden Accessories
+If you have hidden an accessory from the Home View:
+1. Tap the **Rooms** tab (or select the specific Room from the Home menu).
+2. Navigate to the room where the accessory was assigned (e.g., "Living Room").
+3. The accessory tile will be visible there.
+4. To unhide it, long-press the tile -> **Accessory Details** -> Turn **Show in Home View** back **ON**.
+
+---
+
+For more details on available options, see the [Air Conditioner Documentation](ac.md).

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -5,6 +5,7 @@ This guide provides examples of how to use the various switches and sensors prov
 ## Prerequisites
 
 To follow some of these examples, you might need additional plugins:
+
 - [homebridge-delay-switch](https://www.npmjs.com/package/homebridge-delay-switch): For timers with triggers.
 - [homebridge-dummy-legacy](https://www.npmjs.com/package/homebridge-dummy-legacy): For state persistence or virtual triggers (preferred version).
 
@@ -12,11 +13,13 @@ To follow some of these examples, you might need additional plugins:
 > If you are using a **Child Bridge** for the Midea platform (recommended), you must pair it separately in HomeKit using its own QR code from the Homebridge UI.
 
 ### Configuration Example for `homebridge-dummy-legacy`
+
 Unlike some other plugins, this one must be added to the **`accessories`** section of your `config.json`:
+
 ```json
 {
-    "accessory": "DummySwitch",
-    "name": "AC Cool Mode Active"
+  "accessory": "DummySwitch",
+  "name": "AC Cool Mode Active"
 }
 ```
 
@@ -25,14 +28,17 @@ Unlike some other plugins, this one must be added to the **`accessories`** secti
 The plugin includes a built-in timer that doesn't require extra plugins.
 
 ### Configuration
+
 Ensure `"timerSwitch": true` is set in your `AC_options`.
 
 ### How it works
+
 1. In HomeKit, you will see a **Valve** accessory named "Timer".
 2. Open its settings to set a "Duration" (e.g., 1 hour).
 3. When you turn on this "Timer", the AC will automatically turn off when the duration expires.
 
 ### Automation
+
 - **Trigger**: When AC is turned on.
 - **Action**: Turn on the "Timer".
 - **Result**: Your AC will always turn off automatically after the set duration.
@@ -42,16 +48,18 @@ Ensure `"timerSwitch": true` is set in your `AC_options`.
 If you want more control, like turning off the AC only if it's still running after a certain delay.
 
 ### Configuration (`homebridge-delay-switch`)
+
 ```json
 {
-    "accessory": "DelaySwitch",
-    "name": "AC Timeout",
-    "delay": 7200000,
-    "startOnReboot": false
+  "accessory": "DelaySwitch",
+  "name": "AC Timeout",
+  "delay": 7200000,
+  "startOnReboot": false
 }
 ```
 
 ### Automations
+
 1. **Start Timer**: When Midea AC Power is turned ON -> Turn ON "AC Timeout".
 2. **Reset Timer**: When Midea AC Power is turned OFF -> Turn OFF "AC Timeout".
 3. **Execution**: When "AC Timeout" Motion Sensor detects motion (triggered when timer expires) -> Turn OFF Midea AC.
@@ -61,18 +69,20 @@ If you want more control, like turning off the AC only if it's still running aft
 Running the fan for a few minutes after using the AC in cooling mode helps dry the internal components and prevents mold growth.
 
 ### Prerequisites
+
 - Enable `"fanOnlyModeSwitch": true` in `AC_options`.
 - A `DelaySwitch` set to 600000 ms (10 minutes).
 
 ### Automations
-1. **State Tracking**: 
-    - When the AC changes to **Cool** mode -> Turn ON "AC Cool Mode Active" (Dummy Switch).
-    - When the AC changes to a mode other than Cool -> Turn OFF "AC Cool Mode Active".
+
+1. **State Tracking**:
+   - When the AC changes to **Cool** mode -> Turn ON "AC Cool Mode Active" (Dummy Switch).
+   - When the AC changes to a mode other than Cool -> Turn OFF "AC Cool Mode Active".
 2. **Trigger**: When Midea AC is turned OFF (**Power OFF**).
 3. **Condition**: If "AC Cool Mode Active" is **ON**.
-4. **Action**: 
-    - Activate "Midea AC Fan Only".
-    - Activate "Dry Timer" (Delay Switch).
+4. **Action**:
+   - Activate "Midea AC Fan Only".
+   - Activate "Dry Timer" (Delay Switch).
 5. **Cleanup**: When "Dry Timer" Motion Sensor detects motion (end of delay) -> Turn OFF "Midea AC Fan Only".
 
 ## Scenario 4: Night Mode
@@ -80,21 +90,24 @@ Running the fan for a few minutes after using the AC in cooling mode helps dry t
 Turn off the noisy features and bright LED when it's time to sleep.
 
 ### Prerequisites
+
 - Enable `"sleepModeSwitch": true`, `"displaySwitch": true`, and `"outSilentSwitch": true`.
 
 ### Automation
+
 - **Trigger**: At 10:00 PM.
 - **Condition**: If Midea AC is ON.
 - **Action**:
-    - Turn ON "Midea AC Sleep Mode".
-    - Turn OFF "Midea AC Display".
-    - Turn ON "Midea AC Outdoor Silent".
+  - Turn ON "Midea AC Sleep Mode".
+  - Turn OFF "Midea AC Display".
+  - Turn ON "Midea AC Outdoor Silent".
 
 ## Scenario 5: Temperature-Based Automation
 
 Turn on the AC when it gets too hot, but only if someone is home.
 
 ### Automation
+
 - **Trigger**: When Midea AC Temperature Sensor rises above 25°C.
 - **Condition**: If anyone is at home.
 - **Action**: Turn ON Midea AC (Cool mode, 22°C).
@@ -104,6 +117,7 @@ Turn on the AC when it gets too hot, but only if someone is home.
 ## Tip: Complex Automations without Eve (HomeKit Shortcuts)
 
 If the Home app seems limited for conditions (e.g., "only IF the AC is on"), you can use the built-in **Shortcuts**:
+
 1. Create a new automation in the Home app.
 2. Choose your trigger (e.g., "A specific time of day").
 3. On the accessory selection screen, scroll to the bottom and tap **"Convert to Shortcut"**.
@@ -116,25 +130,29 @@ If the Home app seems limited for conditions (e.g., "only IF the AC is on"), you
 Keep the room at an ideal temperature automatically.
 
 ### Cool Mode (Summer)
+
 - **Trigger**: Indoor temperature rises above 25°C.
 - **Action**: Set AC to **Cool** mode at 21°C.
 
 ### Heat Mode (Winter)
+
 - **Trigger**: Indoor temperature falls below 19°C.
 - **Action**: Set AC to **Heat** mode at 21°C.
 
-*Note: The Home app allows setting these thresholds natively. If you want this to trigger only when you are home, use the "People" option in the automation settings.*
+_Note: The Home app allows setting these thresholds natively. If you want this to trigger only when you are home, use the "People" option in the automation settings._
 
 ## Scenario 7: Auto-Cleaning (Self Clean)
 
 Start cleaning when the device requests it or periodically.
 
 ### Based on device status
+
 - **Prerequisites**: Enable `"selfCleanSwitch": true` in `AC_options`.
 - **Trigger**: When the AC's "Filter Change Indication" changes to "Change Filter".
 - **Action**: Activate the "Midea AC Self Clean" switch.
 
 ### Periodic (Monthly)
+
 - **Trigger**: Once a month on Sunday at 10 AM.
 - **Action**: Activate "Midea AC Self Clean".
 
@@ -143,12 +161,13 @@ Start cleaning when the device requests it or periodically.
 Save energy at night without sacrificing comfort.
 
 ### Automation (Without Eve)
+
 - **Trigger**: At 11:00 PM.
 - **Action**: **Convert to Shortcut** (at the bottom of the list).
 - **Shortcut Logic**:
-    1. Add the **"Control [My Home]"** action -> Select the AC -> Get the status of "Power".
-    2. Add an **"If"** block -> If "Power" is equal to "Yes" (On).
-    3. In the "If": Add the **"Control [My Home]"** action -> Turn ON "Midea AC Eco Mode".
+  1. Add the **"Control [My Home]"** action -> Select the AC -> Get the status of "Power".
+  2. Add an **"If"** block -> If "Power" is equal to "Yes" (On).
+  3. In the "If": Add the **"Control [My Home]"** action -> Turn ON "Midea AC Eco Mode".
 - **Cancellation**: Create a simple inverse rule at 7:00 AM to turn off Eco mode.
 
 ## Scenario 9: Dehumidification Mode (Dry)
@@ -156,6 +175,7 @@ Save energy at night without sacrificing comfort.
 Fight excessive humidity.
 
 ### Automation
+
 - **Prerequisites**: Enable `"dryModeSwitch": true` and `"humiditySensor": true` in `AC_options`.
 - **Trigger**: When indoor humidity rises above 65% (Humidity Sensor).
 - **Action**: Activate the "Midea AC Dry Mode" switch.
@@ -175,7 +195,9 @@ To keep your Home app clean, you can hide the virtual switches (`DelaySwitch`, `
 The accessories will continue to work perfectly in your automations even when hidden.
 
 ### How to Find Hidden Accessories
+
 If you have hidden an accessory from the Home View:
+
 1. Tap the **Rooms** tab (or select the specific Room from the Home menu).
 2. Navigate to the room where the accessory was assigned (e.g., "Living Room").
 3. The accessory tile will be visible there.

--- a/docs/wifi-setup.md
+++ b/docs/wifi-setup.md
@@ -1,0 +1,36 @@
+### Wi-Fi Setup & Provisioning
+
+If your Midea device is not connected to your Wi-Fi network, it cannot be discovered or controlled by this plugin. This guide explains how to get your device back online.
+
+#### 1. Put the Device in AP Mode
+
+To connect your device to Wi-Fi, you must first put it in **AP (Access Point)** mode.
+
+- **For most Air Conditioners**: Press the **LED** or **Do Not Disturb** button on your remote control **7 times** within 10 seconds.
+- The unit's display should show **"AP"**.
+- The device will now broadcast its own Wi-Fi network (usually named `net_ac_xxxx` or `midea_ac_xxxx`).
+
+#### 2. Provisioning (Connecting to your Home Wi-Fi)
+
+Provisioning is the step where you send your Wi-Fi name and password to the device.
+
+**Important Note**: Unlike discovery, there is currently no reliable and simple command-line tool for this step. Using the official app is **mandatory** to connect the device to your Wi-Fi for the first time.
+
+1. Download the **NetHome Plus** or **Midea SmartHome** app.
+2. Add a new device and follow the instructions to connect it to your 2.4GHz Wi-Fi.
+3. Once the device is connected to your Wi-Fi (the Wi-Fi symbol on the unit becomes solid), it will be visible in Homebridge.
+4. **Important**: Once connected, you don't have to keep the device linked to your personal account if you use the plugin's "Default Profile" option (see step 4).
+
+#### 3. Common Issues
+
+- **2.4GHz Only**: Midea Wi-Fi modules only support **2.4GHz** networks. Ensure your phone/server and the device are not trying to use 5GHz during setup.
+- **Special Characters**: Avoid special characters in your Wi-Fi SSID or Password.
+- **Distance**: Ensure the Wi-Fi signal is strong enough at the device location.
+
+#### 4. Next Steps
+
+Once your device is connected to your Wi-Fi (test it with a `ping` to its IP address):
+
+1. Go to the Homebridge UI.
+2. Use the **Discover** feature in the Midea Platform settings.
+3. If you don't have a Midea account, check the **"Use default NetHome Plus profile"** option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jouskaio/homebridge-midea-portasplit",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jouskaio/homebridge-midea-portasplit",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,12 @@
 {
-  "name": "homebridge-midea-platform",
-  "version": "1.3.3",
+  "name": "@jouskaio/homebridge-midea-portasplit",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "homebridge-midea-platform",
-      "version": "1.3.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/kovapatrik"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/kovapatrik"
-        }
-      ],
+      "name": "@jouskaio/homebridge-midea-portasplit",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jouskaio/homebridge-midea-portasplit",
-  "version": "1.3.4",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jouskaio/homebridge-midea-portasplit",
-      "version": "1.3.4",
+      "version": "1.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,14 @@
     "build:ui": "rolldown -c rolldown.config.ts",
     "prepublishOnly": "npm run lint && npm run fmt:check && npm run build",
     "fmt": "oxfmt",
-    "fmt:check": "oxfmt --check"
+    "fmt:check": "oxfmt --check",
+    "deploy": "npm run build && rsync -avz --delete --exclude 'node_modules' --exclude '.git' . root@192.168.1.102:/var/lib/homebridge/node_modules/homebridge-midea-platform && ssh root@192.168.1.102 'cd /var/lib/homebridge/node_modules/homebridge-midea-platform && npm install --production && hb-service restart'",
+    "setup-remote": "ssh root@192.168.1.102 'apt-get update && apt-get install -y rsync && hb-service update-node 22 && mkdir -p /var/lib/homebridge/node_modules/homebridge-midea-platform && cd /var/lib/homebridge/node_modules/homebridge-midea-platform && npm install --production'"
   },
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.2.4",
     "axios": "^1.18.1",
+    "fakegato-history": "^0.6.6",
     "fast-xml-parser": "^5.9.3",
     "lodash-es": "^4.18.1",
     "luxon": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.3.4",
   "description": "Homebridge plugin for Midea devices",
   "keywords": [
-    "homebridge-plugin"
+    "ac",
+    "air-conditioner",
+    "homebridge-plugin",
+    "midea",
+    "portasplit"
   ],
   "bugs": {
     "url": "https://github.com/Jouskaio/homebridge-midea-platform/issues"
@@ -13,12 +17,12 @@
     "type": "git",
     "url": "git+https://github.com/Jouskaio/homebridge-midea-platform.git"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "funding": [],
   "type": "module",
   "main": "dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jouskaio/homebridge-midea-portasplit",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Homebridge plugin for Midea devices",
   "keywords": [
     "ac",

--- a/package.json
+++ b/package.json
@@ -1,28 +1,22 @@
 {
-  "name": "homebridge-midea-platform",
-  "version": "1.3.3",
+  "name": "@jouskaio/homebridge-midea-portasplit",
+  "version": "1.3.4",
   "description": "Homebridge plugin for Midea devices",
   "keywords": [
     "homebridge-plugin"
   ],
   "bugs": {
-    "url": "https://github.com/kovapatrik/homebridge-midea/issues"
+    "url": "https://github.com/Jouskaio/homebridge-midea-platform/issues"
   },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kovapatrik/homebridge-midea-platform.git"
+    "url": "git+https://github.com/Jouskaio/homebridge-midea-platform.git"
   },
-  "funding": [
-    {
-      "type": "github",
-      "url": "https://github.com/sponsors/kovapatrik"
-    },
-    {
-      "type": "buymeacoffee",
-      "url": "https://www.buymeacoffee.com/kovapatrik"
-    }
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "funding": [],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
@@ -33,9 +27,7 @@
     "build:ui": "rolldown -c rolldown.config.ts",
     "prepublishOnly": "npm run lint && npm run fmt:check && npm run build",
     "fmt": "oxfmt",
-    "fmt:check": "oxfmt --check",
-    "deploy": "npm run build && rsync -avz --delete --exclude 'node_modules' --exclude '.git' . root@192.168.1.102:/var/lib/homebridge/node_modules/homebridge-midea-platform && ssh root@192.168.1.102 'cd /var/lib/homebridge/node_modules/homebridge-midea-platform && npm install --production && hb-service restart'",
-    "setup-remote": "ssh root@192.168.1.102 'apt-get update && apt-get install -y rsync && hb-service update-node 22 && mkdir -p /var/lib/homebridge/node_modules/homebridge-midea-platform && cd /var/lib/homebridge/node_modules/homebridge-midea-platform && npm install --production'"
+    "fmt:check": "oxfmt --check"
   },
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jouskaio/homebridge-midea-portasplit",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Homebridge plugin for Midea devices",
   "keywords": [
     "ac",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jouskaio/homebridge-midea-portasplit",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Homebridge plugin for Midea devices",
   "keywords": [
     "ac",

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -289,7 +289,6 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
       this.service.addLinkedService(this.fanService);
       this.fanService.getCharacteristic(this.platform.Characteristic.Active)?.onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
 
-      const fanSpeedSteps = this.getFanSpeedSteps();
       const fanRotationSpeedCharacteristic = this.fanService.getCharacteristic(this.platform.Characteristic.RotationSpeed);
       if (fanRotationSpeedCharacteristic) {
         fanRotationSpeedCharacteristic.setProps({
@@ -614,7 +613,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     const currentPowerService = this.accessory.services.find((s) => s.subtype === powerWattsSubtype);
     const targetPowerServiceType = this.getDisplayServiceType(this.configDev.AC_options.powerDisplayType);
     if (currentPowerService && (currentPowerService.UUID !== targetPowerServiceType.UUID || this.configDev.AC_options.powerDisplayType === 'None')) {
-      this.platform.log.info(`[${this.device.name}] Removing old power display service (${currentPowerService.UUID === this.platform.Service.LightSensor.UUID ? 'Lux' : 'Other'})`);
+      this.platform.log.info(
+        `[${this.device.name}] Removing old power display service (${currentPowerService.UUID === this.platform.Service.LightSensor.UUID ? 'Lux' : 'Other'})`,
+      );
       this.accessory.removeService(currentPowerService);
       this.powerWattsService = undefined;
     } else {
@@ -644,7 +645,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     const currentEnergyService = this.accessory.services.find((s) => s.subtype === energykWhSubtype);
     const targetEnergyServiceType = this.getDisplayServiceType(this.configDev.AC_options.energyDisplayType);
     if (currentEnergyService && (currentEnergyService.UUID !== targetEnergyServiceType.UUID || this.configDev.AC_options.energyDisplayType === 'None')) {
-      this.platform.log.info(`[${this.device.name}] Removing old energy display service (${currentEnergyService.UUID === this.platform.Service.LightSensor.UUID ? 'Lux' : 'Other'})`);
+      this.platform.log.info(
+        `[${this.device.name}] Removing old energy display service (${currentEnergyService.UUID === this.platform.Service.LightSensor.UUID ? 'Lux' : 'Other'})`,
+      );
       this.accessory.removeService(currentEnergyService);
       this.energykWhService = undefined;
     } else {
@@ -719,7 +722,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         this.platform.log.info(`[${this.device.name}] Weather service updated (${data.humidity}%), refreshing humidity characteristic.`);
         const humidity = this.getIndoorHumidity();
         if (this.humiditySensorService) {
-          this.platform.log.info(`[${this.device.name}] Updating HumiditySensor service (iid: ${this.humiditySensorService.iid}) characteristic to ${humidity}%`);
+          this.platform.log.info(
+            `[${this.device.name}] Updating HumiditySensor service (iid: ${this.humiditySensorService.iid}) characteristic to ${humidity}%`,
+          );
           this.humiditySensorService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
         } else {
           this.platform.log.warn(`[${this.device.name}] Humidity fallback enabled but Humidity Sensor service is not enabled in config.`);
@@ -746,7 +751,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         this.platform.log.info(`[${this.device.name}] Humidity weather fallback enabled, waiting for first weather update.`);
       }
     } else if (this.platform.platformConfig.weather.enabled && this.configDev.AC_options.humiditySensor) {
-      this.platform.log.info(`[${this.device.name}] Tip: Global Weather Service is enabled. To use it as a fallback for this device, enable "Humidity Weather Fallback" in this device's settings.`);
+      this.platform.log.info(
+        `[${this.device.name}] Tip: Global Weather Service is enabled. To use it as a fallback for this device, enable "Humidity Weather Fallback" in this device's settings.`,
+      );
     }
   }
 
@@ -1245,17 +1252,25 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   getIndoorHumidity(): CharacteristicValue {
     let humidity = this.device.attributes.INDOOR_HUMIDITY;
-    this.platform.log.debug(`[${this.device.name}] getIndoorHumidity: Device reports ${humidity}% (Fallback enabled: ${this.configDev.AC_options.humidityWeatherFallback})`);
+    this.platform.log.debug(
+      `[${this.device.name}] getIndoorHumidity: Device reports ${humidity}% (Fallback enabled: ${this.configDev.AC_options.humidityWeatherFallback})`,
+    );
     if (humidity === undefined || humidity === 0 || humidity === 255) {
       if (this.configDev.AC_options.humidityWeatherFallback) {
         if (this.platform.weatherService.humidity !== undefined) {
-          this.platform.log.info(`[${this.device.name}] Indoor humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`);
+          this.platform.log.info(
+            `[${this.device.name}] Indoor humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`,
+          );
           humidity = this.platform.weatherService.humidity;
         } else {
-          this.platform.log.warn(`[${this.device.name}] Indoor humidity is invalid (${humidity}%) and weather fallback is enabled but no weather data is available yet.`);
+          this.platform.log.warn(
+            `[${this.device.name}] Indoor humidity is invalid (${humidity}%) and weather fallback is enabled but no weather data is available yet.`,
+          );
         }
       } else if (humidity === 0 && this.platform.platformConfig.weather.enabled && !this.accessory.context.fallbackSuggested) {
-        this.platform.log.info(`[${this.device.name}] Device reports 0% humidity. If this is incorrect, enable "Humidity Weather Fallback" in settings to use local weather data.`);
+        this.platform.log.info(
+          `[${this.device.name}] Device reports 0% humidity. If this is incorrect, enable "Humidity Weather Fallback" in settings to use local weather data.`,
+        );
         this.accessory.context.fallbackSuggested = true;
       }
     }

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -1258,7 +1258,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (humidity === undefined || humidity === 0 || humidity === 255) {
       if (this.configDev.AC_options.humidityWeatherFallback) {
         if (this.platform.weatherService.humidity !== undefined) {
-          this.platform.log.info(
+          this.platform.log.debug(
             `[${this.device.name}] Indoor humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`,
           );
           humidity = this.platform.weatherService.humidity;
@@ -1462,10 +1462,10 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         await this.device.set_attribute({ POWER: true });
       }
       if (this.getRateSelect() === 100) {
-        await this.device.set_rate_select(2); // 50%
+        await this.device.set_attribute({ RATE_SELECT: 2 }); // 50%
       }
     } else {
-      await this.device.set_rate_select(0); // 100% (No limit)
+      await this.device.set_attribute({ RATE_SELECT: 0 }); // 100% (No limit)
     }
   }
 
@@ -1506,7 +1506,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (val > 3 && (this.device.attributes.RATE_SELECT === undefined || this.device.attributes.RATE_SELECT > 3)) {
       code = val;
     }
-    await this.device.set_rate_select(code);
+    await this.device.set_attribute({ RATE_SELECT: code });
   }
 
   getSwingAngleCurrentPosition(): CharacteristicValue {

--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -9,6 +9,8 @@
  *
  */
 import type { CharacteristicValue, Service } from 'homebridge';
+// @ts-ignore
+import FakegatoHistory from 'fakegato-history';
 import type MideaACDevice from '../devices/ac/MideaACDevice.js';
 import { type ACAttributes, AUTO_FAN_SPEED } from '../devices/ac/MideaACDevice.js';
 import type { MideaAccessory, MideaPlatform } from '../platform.js';
@@ -21,6 +23,9 @@ const fanOnlySubtype = 'fanOnly';
 const fanSubtype = 'fan';
 const fanAutoSubtype = 'fanAuto';
 const ecoModeSubtype = 'ecoMode';
+const coolModeSubtype = 'coolMode';
+const heatModeSubtype = 'heatMode';
+const autoModeSubtype = 'autoMode';
 const breezeAwaySubtype = 'breezeAway';
 const dryModeSubtype = 'dryMode';
 const boostModeSubtype = 'boostMode';
@@ -35,6 +40,16 @@ const swingAngleSubtype = 'swingAngle';
 const comfortModeSubtype = 'comfortMode';
 const temperatureSensorSubtype = 'temperatureSensor';
 const humiditySensorSubtype = 'humidity';
+const smartEyeSubtype = 'smartEye';
+const audioFeedbackSubtype = 'audioFeedback';
+const timerSubtype = 'timer';
+const powerMeterSubtype = 'powerMeter';
+const powerWattsSubtype = 'powerWatts';
+const energykWhSubtype = 'energykWh';
+
+// Custom characteristics for Eve Home compatibility
+const EVE_POWER_UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
+const EVE_ENERGY_UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
 
 export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice> {
   protected service: Service;
@@ -44,6 +59,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   private fanOnlyService?: Service;
   private fanService?: Service;
   private fanAutoService?: Service;
+  private coolModeService?: Service;
+  private heatModeService?: Service;
+  private autoModeService?: Service;
   private ecoModeService?: Service;
   private breezeAwayService?: Service;
   private dryModeService?: Service;
@@ -59,6 +77,16 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   private comfortModeService?: Service;
   private temperatureSensorService?: Service;
   private humiditySensorService?: Service;
+  private smartEyeService?: Service;
+  private audioFeedbackService?: Service;
+  private timerService?: Service;
+  private powerMeterService?: Service;
+  private powerWattsService?: Service;
+  private energykWhService?: Service;
+  private historyService?: any;
+
+  private timerEnd?: number;
+  private timerTimeout?: NodeJS.Timeout;
 
   private swingAngleMainControl: SwingAngle;
   private heatingThresholdTemperature: number;
@@ -79,6 +107,26 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
     this.useThermostat = this.configDev.AC_options.serviceType === ACServiceType.THERMOSTAT;
 
+    // Misc initialization
+    const swingProps = this.configDev.AC_options.swing;
+    this.swingAngleMainControl =
+      swingProps.mode === SwingMode.VERTICAL || (swingProps.mode === SwingMode.BOTH && swingProps.angleMainControl === SwingAngle.VERTICAL)
+        ? SwingAngle.VERTICAL
+        : SwingAngle.HORIZONTAL;
+
+    this.device.attributes.TEMP_FAHRENHEIT = this.configDev.AC_options.fahrenheit;
+
+    this.heatingThresholdTemperature = limitValue(
+      this.accessory.context?.thresholds?.heatingTemperature ?? this.configDev.AC_options.minTemp,
+      this.configDev.AC_options.minTemp,
+      this.configDev.AC_options.maxTemp,
+    );
+    this.coolingThresholdTemperature = limitValue(
+      this.accessory.context?.thresholds?.coolingTemperature ?? this.configDev.AC_options.maxTemp,
+      this.configDev.AC_options.minTemp,
+      this.configDev.AC_options.maxTemp,
+    );
+
     // Remove old service if switching between service types
     const oldService = this.useThermostat
       ? this.accessory.getService(this.platform.Service.HeaterCooler)
@@ -92,21 +140,30 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
       ? this.accessory.getService(this.platform.Service.Thermostat) || this.accessory.addService(this.platform.Service.Thermostat)
       : this.accessory.getService(this.platform.Service.HeaterCooler) || this.accessory.addService(this.platform.Service.HeaterCooler);
 
-    this.service.setCharacteristic(this.platform.Characteristic.Name, this.device.name);
+    this.handleConfiguredName(this.service, 'main', this.device.name);
 
     // Temperature display units — shared by both service types
     this.service
       .getCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits)
-      .onGet(this.getTemperatureDisplayUnits.bind(this))
-      .onSet(this.setTemperatureDisplayUnits.bind(this));
+      ?.setValue(this.getTemperatureDisplayUnits())
+      ?.onGet(this.getTemperatureDisplayUnits.bind(this))
+      ?.onSet(this.setTemperatureDisplayUnits.bind(this));
 
     // Current temperature — shared by both service types
-    this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature).onGet(this.getCurrentTemperature.bind(this));
+    this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)?.onGet(this.getCurrentTemperature.bind(this));
+
+    // Current relative humidity - for Thermostat
+    if (this.useThermostat) {
+      this.service.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)?.onGet(this.getIndoorHumidity.bind(this));
+    }
+
+    // Filter change indication — shared by both service types
+    this.service.getCharacteristic(this.platform.Characteristic.FilterChangeIndication)?.onGet(this.getFilterChangeIndication.bind(this));
 
     // Service-specific characteristic registration
     this.service
       .getCharacteristic(this.useThermostat ? this.platform.Characteristic.CurrentHeatingCoolingState : this.platform.Characteristic.CurrentHeaterCoolerState)
-      .onGet(this.getCurrentState.bind(this));
+      ?.onGet(this.getCurrentState.bind(this));
 
     const thermostatStateValues = this.configDev.AC_options.heatingCapable
       ? [
@@ -131,65 +188,80 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
     this.service
       .getCharacteristic(this.useThermostat ? this.platform.Characteristic.TargetHeatingCoolingState : this.platform.Characteristic.TargetHeaterCoolerState)
-      .onGet(this.getTargetState.bind(this))
-      .onSet(this.setTargetState.bind(this))
-      .setProps({
+      ?.onGet(this.getTargetState.bind(this))
+      ?.onSet(this.setTargetState.bind(this))
+      ?.setProps({
         validValues: this.useThermostat ? thermostatStateValues : heaterCoolerStateValues,
       });
 
     if (this.useThermostat) {
       this.service
         .getCharacteristic(this.platform.Characteristic.TargetTemperature)
-        .onGet(this.getTargetTemperature.bind(this))
-        .onSet(this.setTargetTemperature.bind(this))
-        .setProps({
+        ?.setProps({
           minValue: this.configDev.AC_options.minTemp,
           maxValue: this.configDev.AC_options.maxTemp,
           minStep: this.configDev.AC_options.tempStep,
-        });
+        })
+        ?.onGet(this.getTargetTemperature.bind(this))
+        ?.onSet(this.setTargetTemperature.bind(this));
     } else {
-      this.service.getCharacteristic(this.platform.Characteristic.Active).onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
+      this.service.getCharacteristic(this.platform.Characteristic.Active)?.onGet(this.getActive.bind(this))?.onSet(this.setActive.bind(this));
 
       this.service
         .getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
-        .onGet(this.getCoolingThresholdTemperature.bind(this))
-        .onSet(this.setCoolingThresholdTemperature.bind(this))
-        .setProps({
+        ?.setProps({
           minValue: this.configDev.AC_options.minTemp,
           maxValue: this.configDev.AC_options.maxTemp,
           minStep: this.configDev.AC_options.tempStep,
-        });
+        })
+        ?.setValue(this.getCoolingThresholdTemperature())
+        ?.onGet(this.getCoolingThresholdTemperature.bind(this))
+        ?.onSet(this.setCoolingThresholdTemperature.bind(this));
 
       this.service
         .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
-        .onGet(this.getHeatingThresholdTemperature.bind(this))
-        .onSet(this.setHeatingThresholdTemperature.bind(this))
-        .setProps({
+        ?.setProps({
           minValue: this.configDev.AC_options.minTemp,
           maxValue: this.configDev.AC_options.maxTemp,
           minStep: this.configDev.AC_options.tempStep,
-        });
+        })
+        ?.setValue(this.getHeatingThresholdTemperature())
+        ?.onGet(this.getHeatingThresholdTemperature.bind(this))
+        ?.onSet(this.setHeatingThresholdTemperature.bind(this));
+    }
 
-      this.service
-        .getCharacteristic(this.platform.Characteristic.RotationSpeed)
+    // Common Fan Control for both service types (Thermostat and HeaterCooler)
+    // This improves compatibility with Android/Google Home via Matter/Bridges
+    const fanSpeedSteps = this.getFanSpeedSteps();
+    const rotationSpeedCharacteristic = this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed);
+    if (rotationSpeedCharacteristic) {
+      rotationSpeedCharacteristic
+        .setProps({
+          minValue: 0,
+          maxValue: 100,
+          minStep: 1,
+          ...(fanSpeedSteps.length > 0 && { validValues: fanSpeedSteps.filter((v) => v <= 100) }),
+        })
+        .setValue(this.getRotationSpeed())
         .onGet(this.getRotationSpeed.bind(this))
         .onSet(this.setRotationSpeed.bind(this));
+    }
 
-      // Swing modes (HeaterCooler only — Thermostat uses the fan accessory for swing)
-      if (this.configDev.AC_options.swing.mode !== SwingMode.NONE) {
-        this.service.getCharacteristic(this.platform.Characteristic.SwingMode).onGet(this.getSwingMode.bind(this)).onSet(this.setSwingMode.bind(this));
-      }
+    // Swing modes (HeaterCooler only — Thermostat uses the fan accessory for swing)
+    if (!this.useThermostat && this.configDev.AC_options.swing.mode !== SwingMode.NONE) {
+      this.service.getCharacteristic(this.platform.Characteristic.SwingMode)?.onGet(this.getSwingMode.bind(this)).onSet(this.setSwingMode.bind(this));
     }
 
     // Outdoor temperature sensor
     this.outDoorTemperatureService = this.accessory.getServiceById(this.platform.Service.TemperatureSensor, outDoorTemperatureSubtype);
     if (this.configDev.AC_options.outDoorTemp) {
       this.outDoorTemperatureService ??= this.accessory.addService(this.platform.Service.TemperatureSensor, undefined, outDoorTemperatureSubtype);
-      this.handleConfiguredName(this.outDoorTemperatureService, outDoorTemperatureSubtype, 'Outdoor');
-      this.outDoorTemperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature).onGet(this.getOutdoorTemperature.bind(this));
+      this.handleConfiguredName(this.outDoorTemperatureService, outDoorTemperatureSubtype, 'Outdoor', this.configDev.AC_options.outDoorTempName);
+      this.service.addLinkedService(this.outDoorTemperatureService);
+      this.outDoorTemperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)?.onGet(this.getOutdoorTemperature.bind(this));
       this.outDoorTemperatureService
         .getCharacteristic(this.platform.Characteristic.StatusFault)
-        .onGet(() =>
+        ?.onGet(() =>
           this.device.attributes.OUTDOOR_TEMPERATURE === undefined
             ? this.platform.Characteristic.StatusFault.GENERAL_FAULT
             : this.platform.Characteristic.StatusFault.NO_FAULT,
@@ -202,8 +274,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.fanOnlyService = this.accessory.getServiceById(this.platform.Service.Switch, fanOnlySubtype);
     if (this.configDev.AC_options.fanOnlyModeSwitch) {
       this.fanOnlyService ??= this.accessory.addService(this.platform.Service.Switch, undefined, fanOnlySubtype);
-      this.handleConfiguredName(this.fanOnlyService, fanOnlySubtype, 'Fan-only Mode');
-      this.fanOnlyService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getFanOnlyMode.bind(this)).onSet(this.setFanOnlyMode.bind(this));
+      this.handleConfiguredName(this.fanOnlyService, fanOnlySubtype, 'Mode: Fan', this.configDev.AC_options.fanOnlyModeSwitchName);
+      this.service.addLinkedService(this.fanOnlyService);
+      this.fanOnlyService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getFanOnlyMode.bind(this)).onSet(this.setFanOnlyMode.bind(this));
     } else if (this.fanOnlyService) {
       this.accessory.removeService(this.fanOnlyService);
     }
@@ -212,14 +285,24 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.fanService = this.accessory.getServiceById(this.platform.Service.Fanv2, fanSubtype);
     if (this.configDev.AC_options.fanAccessory) {
       this.fanService ??= this.accessory.addService(this.platform.Service.Fanv2, undefined, fanSubtype);
-      this.handleConfiguredName(this.fanService, fanSubtype, 'Fan');
-      this.fanService.getCharacteristic(this.platform.Characteristic.Active).onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
-      this.fanService
-        .getCharacteristic(this.platform.Characteristic.RotationSpeed)
-        .onGet(this.getRotationSpeed.bind(this))
-        .onSet(this.setRotationSpeed.bind(this));
-      this.fanService.getCharacteristic(this.platform.Characteristic.TargetFanState).onGet(this.getFanState.bind(this)).onSet(this.setFanState.bind(this));
-      this.fanService.getCharacteristic(this.platform.Characteristic.SwingMode).onGet(this.getSwingMode.bind(this)).onSet(this.setSwingMode.bind(this));
+      this.handleConfiguredName(this.fanService, fanSubtype, 'Fan', this.configDev.AC_options.fanAccessoryName);
+      this.service.addLinkedService(this.fanService);
+      this.fanService.getCharacteristic(this.platform.Characteristic.Active)?.onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
+
+      const fanSpeedSteps = this.getFanSpeedSteps();
+      const fanRotationSpeedCharacteristic = this.fanService.getCharacteristic(this.platform.Characteristic.RotationSpeed);
+      if (fanRotationSpeedCharacteristic) {
+        fanRotationSpeedCharacteristic.setProps({
+          minValue: 0,
+          maxValue: 100,
+          minStep: 1,
+          ...(fanSpeedSteps.length > 0 && { validValues: fanSpeedSteps.filter((v) => v <= 100) }),
+        });
+        fanRotationSpeedCharacteristic.onGet(this.getRotationSpeed.bind(this)).onSet(this.setRotationSpeed.bind(this));
+      }
+
+      this.fanService.getCharacteristic(this.platform.Characteristic.TargetFanState)?.onGet(this.getFanState.bind(this)).onSet(this.setFanState.bind(this));
+      this.fanService.getCharacteristic(this.platform.Characteristic.SwingMode)?.onGet(this.getSwingMode.bind(this)).onSet(this.setSwingMode.bind(this));
     } else if (this.fanService) {
       this.accessory.removeService(this.fanService);
     }
@@ -228,19 +311,21 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.fanAutoService = this.accessory.getServiceById(this.platform.Service.Switch, fanAutoSubtype);
     if (this.configDev.AC_options.fanAutoSwitch) {
       this.fanAutoService ??= this.accessory.addService(this.platform.Service.Switch, undefined, fanAutoSubtype);
-      this.handleConfiguredName(this.fanAutoService, fanAutoSubtype, 'Fan Auto');
-      this.fanAutoService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getFanState.bind(this)).onSet(this.setFanAuto.bind(this));
+      this.handleConfiguredName(this.fanAutoService, fanAutoSubtype, 'Fan Auto', this.configDev.AC_options.fanAutoSwitchName);
+      this.service.addLinkedService(this.fanAutoService);
+      this.fanAutoService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getFanState.bind(this)).onSet(this.setFanAuto.bind(this));
     } else if (this.fanAutoService) {
       this.accessory.removeService(this.fanAutoService);
     }
 
     // Display switch
     this.displayService = this.accessory.getServiceById(this.platform.Service.Switch, displaySubtype);
-    if (this.configDev.AC_options.displaySwitch.flag) {
-      this.device.set_alternate_switch_display(this.configDev.AC_options.displaySwitch.command);
+    if (this.configDev.AC_options.displaySwitch) {
+      this.device.set_alternate_switch_display(this.configDev.AC_options.displaySwitchAlternate);
       this.displayService ??= this.accessory.addService(this.platform.Service.Switch, undefined, displaySubtype);
-      this.handleConfiguredName(this.displayService, displaySubtype, 'Display');
-      this.displayService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getDisplayActive.bind(this)).onSet(this.setDisplayActive.bind(this));
+      this.handleConfiguredName(this.displayService, displaySubtype, 'Display', this.configDev.AC_options.displaySwitchName);
+      this.service.addLinkedService(this.displayService);
+      this.displayService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getDisplayActive.bind(this)).onSet(this.setDisplayActive.bind(this));
     } else if (this.displayService) {
       this.accessory.removeService(this.displayService);
     }
@@ -249,18 +334,52 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.ecoModeService = this.accessory.getServiceById(this.platform.Service.Switch, ecoModeSubtype);
     if (this.configDev.AC_options.ecoSwitch) {
       this.ecoModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, ecoModeSubtype);
-      this.handleConfiguredName(this.ecoModeService, ecoModeSubtype, 'Eco');
-      this.ecoModeService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getEcoMode.bind(this)).onSet(this.setEcoMode.bind(this));
+      this.handleConfiguredName(this.ecoModeService, ecoModeSubtype, 'Eco', this.configDev.AC_options.ecoSwitchName);
+      this.service.addLinkedService(this.ecoModeService);
+      this.ecoModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getEcoMode.bind(this)).onSet(this.setEcoMode.bind(this));
     } else if (this.ecoModeService) {
       this.accessory.removeService(this.ecoModeService);
+    }
+
+    // Cool mode switch
+    this.coolModeService = this.accessory.getServiceById(this.platform.Service.Switch, coolModeSubtype);
+    if (this.configDev.AC_options.coolModeSwitch) {
+      this.coolModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, coolModeSubtype);
+      this.handleConfiguredName(this.coolModeService, coolModeSubtype, 'Mode: Cool', this.configDev.AC_options.coolModeSwitchName);
+      this.service.addLinkedService(this.coolModeService);
+      this.coolModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getCoolMode.bind(this)).onSet(this.setCoolMode.bind(this));
+    } else if (this.coolModeService) {
+      this.accessory.removeService(this.coolModeService);
+    }
+
+    // Heat mode switch
+    this.heatModeService = this.accessory.getServiceById(this.platform.Service.Switch, heatModeSubtype);
+    if (this.configDev.AC_options.heatModeSwitch) {
+      this.heatModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, heatModeSubtype);
+      this.handleConfiguredName(this.heatModeService, heatModeSubtype, 'Mode: Heat', this.configDev.AC_options.heatModeSwitchName);
+      this.service.addLinkedService(this.heatModeService);
+      this.heatModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getHeatMode.bind(this)).onSet(this.setHeatMode.bind(this));
+    } else if (this.heatModeService) {
+      this.accessory.removeService(this.heatModeService);
+    }
+
+    // Auto mode switch
+    this.autoModeService = this.accessory.getServiceById(this.platform.Service.Switch, autoModeSubtype);
+    if (this.configDev.AC_options.autoModeSwitch) {
+      this.autoModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, autoModeSubtype);
+      this.handleConfiguredName(this.autoModeService, autoModeSubtype, 'Mode: Auto', this.configDev.AC_options.autoModeSwitchName);
+      this.service.addLinkedService(this.autoModeService);
+      this.autoModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getAutoMode.bind(this)).onSet(this.setAutoMode.bind(this));
+    } else if (this.autoModeService) {
+      this.accessory.removeService(this.autoModeService);
     }
 
     // Breeze away switch
     this.breezeAwayService = this.accessory.getServiceById(this.platform.Service.Switch, breezeAwaySubtype);
     if (this.configDev.AC_options.breezeAwaySwitch) {
       this.breezeAwayService ??= this.accessory.addService(this.platform.Service.Switch, undefined, breezeAwaySubtype);
-      this.handleConfiguredName(this.breezeAwayService, breezeAwaySubtype, 'Breeze');
-      this.breezeAwayService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getBreezeAway.bind(this)).onSet(this.setBreezeAway.bind(this));
+      this.handleConfiguredName(this.breezeAwayService, breezeAwaySubtype, 'Breeze', this.configDev.AC_options.breezeAwaySwitchName);
+      this.breezeAwayService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getBreezeAway.bind(this)).onSet(this.setBreezeAway.bind(this));
     } else if (this.breezeAwayService) {
       this.accessory.removeService(this.breezeAwayService);
     }
@@ -269,8 +388,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.dryModeService = this.accessory.getServiceById(this.platform.Service.Switch, dryModeSubtype);
     if (this.configDev.AC_options.dryModeSwitch) {
       this.dryModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, dryModeSubtype);
-      this.handleConfiguredName(this.dryModeService, dryModeSubtype, 'Dry');
-      this.dryModeService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getDryMode.bind(this)).onSet(this.setDryMode.bind(this));
+      this.handleConfiguredName(this.dryModeService, dryModeSubtype, 'Mode: Dry', this.configDev.AC_options.dryModeSwitchName);
+      this.service.addLinkedService(this.dryModeService);
+      this.dryModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getDryMode.bind(this)).onSet(this.setDryMode.bind(this));
     } else if (this.dryModeService) {
       this.accessory.removeService(this.dryModeService);
     }
@@ -279,8 +399,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.boostModeService = this.accessory.getServiceById(this.platform.Service.Switch, boostModeSubtype);
     if (this.configDev.AC_options.boostModeSwitch) {
       this.boostModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, boostModeSubtype);
-      this.handleConfiguredName(this.boostModeService, boostModeSubtype, 'Boost');
-      this.boostModeService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getBoostMode.bind(this)).onSet(this.setBoostMode.bind(this));
+      this.handleConfiguredName(this.boostModeService, boostModeSubtype, 'Boost', this.configDev.AC_options.boostModeSwitchName);
+      this.service.addLinkedService(this.boostModeService);
+      this.boostModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getBoostMode.bind(this)).onSet(this.setBoostMode.bind(this));
     } else if (this.boostModeService) {
       this.accessory.removeService(this.boostModeService);
     }
@@ -289,8 +410,8 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.auxService = this.accessory.getServiceById(this.platform.Service.Switch, auxSubtype);
     if (this.configDev.AC_options.auxHeatingSwitches) {
       this.auxService ??= this.accessory.addService(this.platform.Service.Switch, undefined, auxSubtype);
-      this.handleConfiguredName(this.auxService, auxSubtype, 'Aux');
-      this.auxService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getAux.bind(this)).onSet(this.setAux.bind(this));
+      this.handleConfiguredName(this.auxService, auxSubtype, 'Aux', this.configDev.AC_options.auxHeatingSwitchesName);
+      this.auxService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getAux.bind(this)).onSet(this.setAux.bind(this));
     } else if (this.auxService) {
       this.accessory.removeService(this.auxService);
     }
@@ -299,8 +420,8 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.auxHeatingService = this.accessory.getServiceById(this.platform.Service.Switch, auxHeatingSubtype);
     if (this.configDev.AC_options.auxHeatingSwitches) {
       this.auxHeatingService ??= this.accessory.addService(this.platform.Service.Switch, undefined, auxHeatingSubtype);
-      this.handleConfiguredName(this.auxHeatingService, auxHeatingSubtype, 'Aux+Heat');
-      this.auxHeatingService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getAuxHeating.bind(this)).onSet(this.setAuxHeating.bind(this));
+      this.handleConfiguredName(this.auxHeatingService, auxHeatingSubtype, 'Aux+Heat', this.configDev.AC_options.auxHeatingSwitchesPlusHeatName);
+      this.auxHeatingService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getAuxHeating.bind(this)).onSet(this.setAuxHeating.bind(this));
     } else if (this.auxHeatingService) {
       this.accessory.removeService(this.auxHeatingService);
     }
@@ -309,10 +430,11 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.selfCleanService = this.accessory.getServiceById(this.platform.Service.Switch, selfCleanSubtype);
     if (this.configDev.AC_options.selfCleanSwitch) {
       this.selfCleanService ??= this.accessory.addService(this.platform.Service.Switch, undefined, selfCleanSubtype);
-      this.handleConfiguredName(this.selfCleanService, selfCleanSubtype, 'Self-cleaning');
+      this.handleConfiguredName(this.selfCleanService, selfCleanSubtype, 'Mode: Auto Clean', this.configDev.AC_options.selfCleanSwitchName);
+      this.service.addLinkedService(this.selfCleanService);
       this.selfCleanService
         .getCharacteristic(this.platform.Characteristic.On)
-        .onGet(this.getSelfCleanState.bind(this))
+        ?.onGet(this.getSelfCleanState.bind(this))
         .onSet(this.setSelfCleanState.bind(this));
     } else if (this.selfCleanService) {
       this.accessory.removeService(this.selfCleanService);
@@ -322,8 +444,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.ionService = this.accessory.getServiceById(this.platform.Service.Switch, ionSubtype);
     if (this.configDev.AC_options.ionSwitch) {
       this.ionService ??= this.accessory.addService(this.platform.Service.Switch, undefined, ionSubtype);
-      this.handleConfiguredName(this.ionService, ionSubtype, 'ION');
-      this.ionService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getIonState.bind(this)).onSet(this.setIonState.bind(this));
+      this.handleConfiguredName(this.ionService, ionSubtype, 'ION', this.configDev.AC_options.ionSwitchName);
+      this.service.addLinkedService(this.ionService);
+      this.ionService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getIonState.bind(this)).onSet(this.setIonState.bind(this));
     } else if (this.ionService) {
       this.accessory.removeService(this.ionService);
     }
@@ -332,8 +455,8 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.outSilentService = this.accessory.getServiceById(this.platform.Service.Switch, outSilentSubtype);
     if (this.configDev.AC_options.outSilentSwitch) {
       this.outSilentService ??= this.accessory.addService(this.platform.Service.Switch, undefined, outSilentSubtype);
-      this.handleConfiguredName(this.outSilentService, outSilentSubtype, 'Out Silent');
-      this.outSilentService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getOutSilent.bind(this)).onSet(this.setOutSilent.bind(this));
+      this.handleConfiguredName(this.outSilentService, outSilentSubtype, 'Out Silent', this.configDev.AC_options.outSilentSwitchName);
+      this.outSilentService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getOutSilent.bind(this)).onSet(this.setOutSilent.bind(this));
     } else if (this.outSilentService) {
       this.accessory.removeService(this.outSilentService);
     }
@@ -342,15 +465,18 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.rateSelectService = this.accessory.getServiceById(this.platform.Service.Lightbulb, rateSelectSubtype);
     if (this.configDev.AC_options.rateSelector) {
       this.rateSelectService ??= this.accessory.addService(this.platform.Service.Lightbulb, undefined, rateSelectSubtype);
-      this.handleConfiguredName(this.rateSelectService, rateSelectSubtype, 'Gear');
-      this.rateSelectService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
+      this.handleConfiguredName(this.rateSelectService, rateSelectSubtype, 'Gear', this.configDev.AC_options.rateSelectorName);
+      this.service.addLinkedService(this.rateSelectService);
+      this.rateSelectService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getRateSelectOn.bind(this))?.onSet(this.setRateSelectOn.bind(this));
       this.rateSelectService
         .getCharacteristic(this.platform.Characteristic.Brightness)
-        .setProps({
-          validValues: [0, 50, 75, 100],
+        ?.setProps({
+          minValue: 0,
+          maxValue: 100,
+          minStep: 1,
         })
-        .onGet(this.getRateSelect.bind(this))
-        .onSet(this.setRateSelect.bind(this));
+        ?.onGet(this.getRateSelect.bind(this))
+        ?.onSet(this.setRateSelect.bind(this));
     } else if (this.rateSelectService) {
       this.accessory.removeService(this.rateSelectService);
     }
@@ -359,8 +485,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.sleepModeService = this.accessory.getServiceById(this.platform.Service.Switch, sleepModeSubtype);
     if (this.configDev.AC_options.sleepModeSwitch) {
       this.sleepModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, sleepModeSubtype);
-      this.handleConfiguredName(this.sleepModeService, sleepModeSubtype, 'Sleep');
-      this.sleepModeService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getSleepMode.bind(this)).onSet(this.setSleepMode.bind(this));
+      this.handleConfiguredName(this.sleepModeService, sleepModeSubtype, 'Sleep', this.configDev.AC_options.sleepModeSwitchName);
+      this.service.addLinkedService(this.sleepModeService);
+      this.sleepModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getSleepMode.bind(this)).onSet(this.setSleepMode.bind(this));
     } else if (this.sleepModeService) {
       this.accessory.removeService(this.sleepModeService);
     }
@@ -369,8 +496,8 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.comfortModeService = this.accessory.getServiceById(this.platform.Service.Switch, comfortModeSubtype);
     if (this.configDev.AC_options.comfortModeSwitch) {
       this.comfortModeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, comfortModeSubtype);
-      this.handleConfiguredName(this.comfortModeService, comfortModeSubtype, 'Comfort');
-      this.comfortModeService.getCharacteristic(this.platform.Characteristic.On).onGet(this.getComfortMode.bind(this)).onSet(this.setComfortMode.bind(this));
+      this.handleConfiguredName(this.comfortModeService, comfortModeSubtype, 'Comfort', this.configDev.AC_options.comfortModeSwitchName);
+      this.comfortModeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getComfortMode.bind(this)).onSet(this.setComfortMode.bind(this));
     } else if (this.comfortModeService) {
       this.accessory.removeService(this.comfortModeService);
     }
@@ -379,8 +506,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.temperatureSensorService = this.accessory.getServiceById(this.platform.Service.TemperatureSensor, temperatureSensorSubtype);
     if (this.configDev.AC_options.temperatureSensor) {
       this.temperatureSensorService ??= this.accessory.addService(this.platform.Service.TemperatureSensor, undefined, temperatureSensorSubtype);
-      this.handleConfiguredName(this.temperatureSensorService, temperatureSensorSubtype, 'Indoor Temperature');
-      this.temperatureSensorService.getCharacteristic(this.platform.Characteristic.CurrentTemperature).onGet(this.getCurrentTemperature.bind(this));
+      this.handleConfiguredName(this.temperatureSensorService, temperatureSensorSubtype, 'Indoor Temperature', this.configDev.AC_options.temperatureSensorName);
+      this.service.addLinkedService(this.temperatureSensorService);
+      this.temperatureSensorService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)?.onGet(this.getCurrentTemperature.bind(this));
     } else if (this.temperatureSensorService) {
       this.accessory.removeService(this.temperatureSensorService);
     }
@@ -389,54 +517,237 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     this.humiditySensorService = this.accessory.getServiceById(this.platform.Service.HumiditySensor, humiditySensorSubtype);
     if (this.configDev.AC_options.humiditySensor) {
       this.humiditySensorService ??= this.accessory.addService(this.platform.Service.HumiditySensor, undefined, humiditySensorSubtype);
-      this.handleConfiguredName(this.humiditySensorService, humiditySensorSubtype, 'Humidity');
-      this.humiditySensorService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).onGet(this.getIndoorHumidity.bind(this));
+      this.handleConfiguredName(this.humiditySensorService, humiditySensorSubtype, 'Humidity', this.configDev.AC_options.humiditySensorName);
+      this.service.addLinkedService(this.humiditySensorService);
+      this.humiditySensorService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)?.onGet(this.getIndoorHumidity.bind(this));
     } else if (this.humiditySensorService) {
       this.accessory.removeService(this.humiditySensorService);
     }
 
-    const swingProps = this.configDev.AC_options.swing;
-    this.swingAngleMainControl =
-      swingProps.mode === SwingMode.VERTICAL || (swingProps.mode === SwingMode.BOTH && swingProps.angleMainControl === SwingAngle.VERTICAL)
-        ? SwingAngle.VERTICAL
-        : SwingAngle.HORIZONTAL;
+    // Smart Eye switch
+    this.smartEyeService = this.accessory.getServiceById(this.platform.Service.Switch, smartEyeSubtype);
+    if (this.configDev.AC_options.smartEyeSwitch) {
+      this.smartEyeService ??= this.accessory.addService(this.platform.Service.Switch, undefined, smartEyeSubtype);
+      this.handleConfiguredName(this.smartEyeService, smartEyeSubtype, 'iSense', this.configDev.AC_options.smartEyeSwitchName);
+      this.service.addLinkedService(this.smartEyeService);
+      this.smartEyeService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getSmartEye.bind(this)).onSet(this.setSmartEye.bind(this));
+    } else if (this.smartEyeService) {
+      this.accessory.removeService(this.smartEyeService);
+    }
+
+    // Audio Feedback switch
+    this.audioFeedbackService = this.accessory.getServiceById(this.platform.Service.Switch, audioFeedbackSubtype);
+    if (this.configDev.AC_options.audioFeedbackSwitch) {
+      this.audioFeedbackService ??= this.accessory.addService(this.platform.Service.Switch, undefined, audioFeedbackSubtype);
+      this.handleConfiguredName(this.audioFeedbackService, audioFeedbackSubtype, 'Sound', this.configDev.AC_options.audioFeedbackSwitchName);
+      this.service.addLinkedService(this.audioFeedbackService);
+      this.audioFeedbackService
+        .getCharacteristic(this.platform.Characteristic.On)
+        ?.onGet(this.getAudioFeedback.bind(this))
+        .onSet(this.setAudioFeedback.bind(this));
+    } else if (this.audioFeedbackService) {
+      this.accessory.removeService(this.audioFeedbackService);
+    }
+
+    // Timer switch
+    this.timerService = this.accessory.getServiceById(this.platform.Service.Valve, timerSubtype);
+    if (this.configDev.AC_options.timerSwitch) {
+      this.timerService ??= this.accessory.addService(this.platform.Service.Valve, undefined, timerSubtype);
+      this.handleConfiguredName(this.timerService, timerSubtype, 'Timer', this.configDev.AC_options.timerSwitchName);
+      this.service.addLinkedService(this.timerService);
+      this.timerService.getCharacteristic(this.platform.Characteristic.Active)?.onGet(this.getTimerActive.bind(this)).onSet(this.setTimerActive.bind(this));
+      this.timerService.getCharacteristic(this.platform.Characteristic.InUse)?.onGet(this.getTimerActive.bind(this));
+      this.timerService.getCharacteristic(this.platform.Characteristic.ValveType)?.onGet(() => this.platform.Characteristic.ValveType.GENERIC_VALVE);
+      this.timerService.getCharacteristic(this.platform.Characteristic.SetDuration).onSet(this.setTimerDuration.bind(this));
+      this.timerService.getCharacteristic(this.platform.Characteristic.RemainingDuration)?.onGet(this.getTimerRemainingDuration.bind(this));
+    } else if (this.timerService) {
+      this.accessory.removeService(this.timerService);
+    }
+
+    // Power Meter service (Outlet)
+    this.powerMeterService = this.accessory.getServiceById(this.platform.Service.Outlet, powerMeterSubtype);
+    if (this.configDev.AC_options.powerMeter) {
+      this.powerMeterService ??= this.accessory.addService(this.platform.Service.Outlet, undefined, powerMeterSubtype);
+      this.handleConfiguredName(this.powerMeterService, powerMeterSubtype, 'Consumption', this.configDev.AC_options.powerMeterName);
+      this.service.addLinkedService(this.powerMeterService);
+
+      this.powerMeterService.getCharacteristic(this.platform.Characteristic.On)?.onGet(this.getActive.bind(this)).onSet(this.setActive.bind(this));
+
+      this.powerMeterService.getCharacteristic(this.platform.Characteristic.OutletInUse)?.onGet(this.getActive.bind(this));
+
+      // Eve Power
+      if (!this.powerMeterService.characteristics.some((c) => c.UUID === EVE_POWER_UUID)) {
+        try {
+          this.powerMeterService.addCharacteristic(
+            new this.platform.api.hap.Characteristic('Power', EVE_POWER_UUID, {
+              format: this.platform.api.hap.Formats.FLOAT,
+              unit: 'W',
+              perms: [this.platform.api.hap.Perms.PAIRED_READ, this.platform.api.hap.Perms.NOTIFY],
+            }),
+          );
+        } catch (error) {
+          this.platform.log.debug(`[${this.device.name}] Eve Power characteristic already exists: ${error}`);
+        }
+      }
+      this.powerMeterService.getCharacteristic(EVE_POWER_UUID as any)?.onGet(this.getRealtimePower.bind(this));
+
+      // Eve Total Consumption
+      if (!this.powerMeterService.characteristics.some((c) => c.UUID === EVE_ENERGY_UUID)) {
+        try {
+          this.powerMeterService.addCharacteristic(
+            new this.platform.api.hap.Characteristic('Total Consumption', EVE_ENERGY_UUID, {
+              format: this.platform.api.hap.Formats.FLOAT,
+              unit: 'kWh',
+              perms: [this.platform.api.hap.Perms.PAIRED_READ, this.platform.api.hap.Perms.NOTIFY],
+            }),
+          );
+        } catch (error) {
+          this.platform.log.debug(`[${this.device.name}] Eve Total Consumption characteristic already exists: ${error}`);
+        }
+      }
+      this.powerMeterService.getCharacteristic(EVE_ENERGY_UUID as any)?.onGet(this.getTotalEnergyConsumption.bind(this));
+    } else if (this.powerMeterService) {
+      this.accessory.removeService(this.powerMeterService);
+    }
+
+    // Power Watts service (workaround for native Home app visibility)
+    const currentPowerService = this.accessory.services.find((s) => s.subtype === powerWattsSubtype);
+    const targetPowerServiceType = this.getDisplayServiceType(this.configDev.AC_options.powerDisplayType);
+    if (currentPowerService && (currentPowerService.UUID !== targetPowerServiceType.UUID || this.configDev.AC_options.powerDisplayType === 'None')) {
+      this.platform.log.info(`[${this.device.name}] Removing old power display service (${currentPowerService.UUID === this.platform.Service.LightSensor.UUID ? 'Lux' : 'Other'})`);
+      this.accessory.removeService(currentPowerService);
+      this.powerWattsService = undefined;
+    } else {
+      this.powerWattsService = currentPowerService;
+    }
+
+    if (this.configDev.AC_options.powerMeter && this.configDev.AC_options.powerDisplayType !== 'None') {
+      this.powerWattsService ??= this.accessory.addService(targetPowerServiceType, undefined, powerWattsSubtype);
+      this.handleConfiguredName(
+        this.powerWattsService,
+        powerWattsSubtype,
+        `Power (${this.getDisplayUnit(this.configDev.AC_options.powerDisplayType)})`,
+        this.configDev.AC_options.powerMeterName ? `${this.configDev.AC_options.powerMeterName} Watts` : undefined,
+      );
+      this.service.addLinkedService(this.powerWattsService);
+      this.powerWattsService
+        .getCharacteristic(this.getDisplayCharacteristic(this.configDev.AC_options.powerDisplayType))
+        ?.onGet(this.getRealtimePower.bind(this));
+      if (this.configDev.AC_options.powerDisplayType === 'CarbonDioxide') {
+        this.powerWattsService
+          .getCharacteristic(this.platform.Characteristic.CarbonDioxideDetected)
+          ?.onGet(() => this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL);
+      }
+    }
+
+    // Energy kWh service (workaround for native Home app visibility)
+    const currentEnergyService = this.accessory.services.find((s) => s.subtype === energykWhSubtype);
+    const targetEnergyServiceType = this.getDisplayServiceType(this.configDev.AC_options.energyDisplayType);
+    if (currentEnergyService && (currentEnergyService.UUID !== targetEnergyServiceType.UUID || this.configDev.AC_options.energyDisplayType === 'None')) {
+      this.platform.log.info(`[${this.device.name}] Removing old energy display service (${currentEnergyService.UUID === this.platform.Service.LightSensor.UUID ? 'Lux' : 'Other'})`);
+      this.accessory.removeService(currentEnergyService);
+      this.energykWhService = undefined;
+    } else {
+      this.energykWhService = currentEnergyService;
+    }
+
+    if (this.configDev.AC_options.powerMeter && this.configDev.AC_options.energyDisplayType !== 'None') {
+      this.energykWhService ??= this.accessory.addService(targetEnergyServiceType, undefined, energykWhSubtype);
+      this.handleConfiguredName(
+        this.energykWhService,
+        energykWhSubtype,
+        `Energy (${this.getDisplayUnit(this.configDev.AC_options.energyDisplayType)})`,
+        this.configDev.AC_options.powerMeterName ? `${this.configDev.AC_options.powerMeterName} Energy` : undefined,
+      );
+      this.service.addLinkedService(this.energykWhService);
+      this.energykWhService
+        .getCharacteristic(this.getDisplayCharacteristic(this.configDev.AC_options.energyDisplayType))
+        ?.onGet(this.getTotalEnergyConsumption.bind(this));
+      if (this.configDev.AC_options.energyDisplayType === 'CarbonDioxide') {
+        this.energykWhService
+          .getCharacteristic(this.platform.Characteristic.CarbonDioxideDetected)
+          ?.onGet(() => this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL);
+      }
+    }
+
     // Swing angle accessory
     this.swingAngleService = this.accessory.getServiceById(this.platform.Service.WindowCovering, swingAngleSubtype);
-    if (swingProps.mode !== SwingMode.NONE && swingProps.angleAccessory) {
+    if (this.configDev.AC_options.swing.mode !== SwingMode.NONE && this.configDev.AC_options.swing.angleAccessory) {
       this.swingAngleService ??= this.accessory.addService(this.platform.Service.WindowCovering, undefined, swingAngleSubtype);
-      this.handleConfiguredName(this.swingAngleService, swingAngleSubtype, 'Swing');
-      this.swingAngleService.getCharacteristic(this.platform.Characteristic.CurrentPosition).onGet(this.getSwingAngleCurrentPosition.bind(this));
+      this.handleConfiguredName(this.swingAngleService, swingAngleSubtype, 'Swing', this.configDev.AC_options.swing.angleAccessoryName);
+      this.swingAngleService.getCharacteristic(this.platform.Characteristic.CurrentPosition)?.onGet(this.getSwingAngleCurrentPosition.bind(this));
       this.swingAngleService
         .getCharacteristic(this.platform.Characteristic.TargetPosition)
-        .onGet(this.getSwingAngleTargetPosition.bind(this))
+        ?.onGet(this.getSwingAngleTargetPosition.bind(this))
         .onSet(this.setSwingAngleTargetPosition.bind(this));
-      this.swingAngleService.getCharacteristic(this.platform.Characteristic.PositionState).onGet(this.getSwingAnglePositionState.bind(this));
+      this.swingAngleService.getCharacteristic(this.platform.Characteristic.PositionState)?.onGet(this.getSwingAnglePositionState.bind(this));
 
-      if (swingProps.mode === SwingMode.BOTH) {
+      if (this.configDev.AC_options.swing.mode === SwingMode.BOTH) {
         this.swingAngleService
           .getCharacteristic(this.platform.Characteristic.CurrentHorizontalTiltAngle)
-          .onGet(this.getSwingAngleCurrentHorizontalTiltAngle.bind(this));
+          ?.onGet(this.getSwingAngleCurrentHorizontalTiltAngle.bind(this));
         this.swingAngleService
           .getCharacteristic(this.platform.Characteristic.TargetHorizontalTiltAngle)
-          .onGet(this.getSwingAngleTargetHorizontalTiltAngle.bind(this))
+          ?.onGet(this.getSwingAngleTargetHorizontalTiltAngle.bind(this))
           .onSet(this.setSwingAngleTargetHorizontalTiltAngle.bind(this));
         this.swingAngleService
           .getCharacteristic(this.platform.Characteristic.CurrentVerticalTiltAngle)
-          .onGet(this.getSwingAngleCurrentVerticalTiltAngle.bind(this));
+          ?.onGet(this.getSwingAngleCurrentVerticalTiltAngle.bind(this));
         this.swingAngleService
           .getCharacteristic(this.platform.Characteristic.TargetVerticalTiltAngle)
-          .onGet(this.getSwingAngleTargetVerticalTiltAngle.bind(this))
+          ?.onGet(this.getSwingAngleTargetVerticalTiltAngle.bind(this))
           .onSet(this.setSwingAngleTargetVerticalTiltAngle.bind(this));
       }
     } else if (this.swingAngleService) {
       this.accessory.removeService(this.swingAngleService);
     }
     // Misc
-    this.device.attributes.PROMPT_TONE = configDev.AC_options.audioFeedback;
-    this.device.attributes.TEMP_FAHRENHEIT = configDev.AC_options.fahrenheit;
+    this.initialized = true;
 
-    this.heatingThresholdTemperature = accessory.context?.thresholds?.heatingTemperature ?? configDev.AC_options.minTemp;
-    this.coolingThresholdTemperature = accessory.context?.thresholds?.coolingTemperature ?? configDev.AC_options.maxTemp;
+    // Eve History
+    if (this.configDev.AC_options.powerMeter) {
+      const FakeGatoHistoryService = FakegatoHistory(this.platform.api);
+      this.historyService = new FakeGatoHistoryService('energy', this.accessory, {
+        storage: 'fs',
+        log: this.platform.log,
+      });
+    }
+
+    // Weather Service updates
+    this.platform.weatherService.on('update', (data) => {
+      if (this.configDev.AC_options.humidityWeatherFallback) {
+        this.platform.log.info(`[${this.device.name}] Weather service updated (${data.humidity}%), refreshing humidity characteristic.`);
+        const humidity = this.getIndoorHumidity();
+        if (this.humiditySensorService) {
+          this.platform.log.info(`[${this.device.name}] Updating HumiditySensor service (iid: ${this.humiditySensorService.iid}) characteristic to ${humidity}%`);
+          this.humiditySensorService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        } else {
+          this.platform.log.warn(`[${this.device.name}] Humidity fallback enabled but Humidity Sensor service is not enabled in config.`);
+        }
+        if (this.useThermostat) {
+          this.platform.log.info(`[${this.device.name}] Updating Thermostat service (iid: ${this.service.iid}) characteristic to ${humidity}%`);
+          this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        }
+        this.historyService?.addEntry({ time: Math.round(new Date().getTime() / 1000), humidity: humidity as number });
+      }
+    });
+
+    // Initial weather fallback check
+    if (this.configDev.AC_options.humidityWeatherFallback) {
+      this.platform.log.info(`[${this.device.name}] Humidity weather fallback enabled.`);
+      if (this.platform.weatherService.humidity !== undefined) {
+        const humidity = this.getIndoorHumidity();
+        this.platform.log.info(`[${this.device.name}] Using initial weather fallback humidity: ${humidity}%`);
+        this.humiditySensorService?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        if (this.useThermostat) {
+          this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        }
+      } else {
+        this.platform.log.info(`[${this.device.name}] Humidity weather fallback enabled, waiting for first weather update.`);
+      }
+    } else if (this.platform.platformConfig.weather.enabled && this.configDev.AC_options.humiditySensor) {
+      this.platform.log.info(`[${this.device.name}] Tip: Global Weather Service is enabled. To use it as a fallback for this device, enable "Humidity Weather Fallback" in this device's settings.`);
+    }
   }
 
   private async withoutPromptTone<T>(fn: () => Promise<T>): Promise<T> {
@@ -455,6 +766,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
    * any attribute value.
    */
   protected async updateCharacteristics(attributes: Partial<ACAttributes>) {
+    let historyEntry: any = {};
     for (const [k, v] of Object.entries(attributes)) {
       this.platform.log.debug(`[${this.device.name}] Set attribute ${k} to: ${v}`);
       let updateState = false;
@@ -463,7 +775,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           updateState = true;
           break;
         case 'temp_fahrenheit':
-          this.service.updateCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits, this.getTemperatureDisplayUnits());
+          this.service?.updateCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits, this.getTemperatureDisplayUnits());
           break;
         case 'screen_display':
         case 'screen_display_new':
@@ -472,7 +784,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         case 'target_temperature': {
           const target = Number(this.getTargetTemperature());
           if (this.useThermostat) {
-            this.service.updateCharacteristic(this.platform.Characteristic.TargetTemperature, target);
+            this.service?.updateCharacteristic(this.platform.Characteristic.TargetTemperature, target);
           } else {
             if (this.device.attributes.MODE === ACMode.HEATING) {
               this.setHeatingCoolingTemperatureThresholds({ heating: target });
@@ -487,8 +799,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         }
         case 'indoor_temperature': {
           const temperature = this.getCurrentTemperature();
-          this.service.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, temperature);
+          this.service?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, temperature);
           this.temperatureSensorService?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, temperature);
+          historyEntry.temp = temperature as number;
           if (!this.useThermostat && this.device.attributes.POWER && this.device.attributes.MODE === ACMode.AUTO) {
             await this.withoutPromptTone(this.setTargetTemperatureWithinThresholds.bind(this));
             updateState = true;
@@ -497,9 +810,44 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         }
         case 'indoor_humidity':
           this.humiditySensorService?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.getIndoorHumidity());
+          if (this.useThermostat) {
+            this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.getIndoorHumidity());
+          }
+          historyEntry.humidity = this.getIndoorHumidity() as number;
+          break;
+        case 'realtime_power':
+          this.powerMeterService?.getCharacteristic(EVE_POWER_UUID as any)?.updateValue(this.getRealtimePower());
+          historyEntry.power = this.getRealtimePower();
+          if (this.powerWattsService) {
+            const char = this.getDisplayCharacteristic(this.configDev.AC_options.powerDisplayType);
+            this.powerWattsService.updateCharacteristic(char, this.getRealtimePower());
+            if (this.configDev.AC_options.powerDisplayType === 'CarbonDioxide') {
+              this.powerWattsService.updateCharacteristic(
+                this.platform.Characteristic.CarbonDioxideDetected,
+                this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL,
+              );
+            }
+          }
+          break;
+        case 'total_energy_consumption':
+          this.powerMeterService?.getCharacteristic(EVE_ENERGY_UUID as any)?.updateValue(this.getTotalEnergyConsumption());
+          historyEntry.energy = this.getTotalEnergyConsumption();
+          if (this.energykWhService) {
+            const char = this.getDisplayCharacteristic(this.configDev.AC_options.energyDisplayType);
+            this.energykWhService.updateCharacteristic(char, this.getTotalEnergyConsumption());
+            if (this.configDev.AC_options.energyDisplayType === 'CarbonDioxide') {
+              this.energykWhService.updateCharacteristic(
+                this.platform.Characteristic.CarbonDioxideDetected,
+                this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL,
+              );
+            }
+          }
           break;
         case 'outdoor_temperature':
           this.outDoorTemperatureService?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, this.getOutdoorTemperature());
+          break;
+        case 'full_dust':
+          this.service?.updateCharacteristic(this.platform.Characteristic.FilterChangeIndication, this.getFilterChangeIndication());
           break;
         case 'fan_speed':
           updateState = true;
@@ -507,7 +855,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         case 'swing_vertical':
         case 'swing_horizontal':
           if (!this.useThermostat) {
-            this.service.updateCharacteristic(this.platform.Characteristic.SwingMode, this.getSwingMode());
+            this.service?.updateCharacteristic(this.platform.Characteristic.SwingMode, this.getSwingMode());
           }
           break;
         case 'mode':
@@ -523,7 +871,10 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           this.auxHeatingService?.updateCharacteristic(this.platform.Characteristic.On, this.getAuxHeating());
           break;
         case 'smart_eye':
-          this.auxService?.updateCharacteristic(this.platform.Characteristic.On, this.getAux());
+          this.smartEyeService?.updateCharacteristic(this.platform.Characteristic.On, this.getSmartEye());
+          break;
+        case 'prompt_tone':
+          this.audioFeedbackService?.updateCharacteristic(this.platform.Characteristic.On, this.getAudioFeedback());
           break;
         case 'wind_swing_lr_angle':
         case 'wind_swing_ud_angle':
@@ -549,26 +900,28 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
           break;
         case 'rate_select':
           this.rateSelectService?.updateCharacteristic(this.platform.Characteristic.Brightness, this.getRateSelect());
+          this.rateSelectService?.updateCharacteristic(this.platform.Characteristic.On, this.getRateSelectOn());
           break;
         default:
           this.platform.log.debug(`[${this.device.name}] Attempt to set unsupported attribute ${k} to ${v}`);
       }
       if (updateState) {
-        this.service.updateCharacteristic(
+        this.service?.updateCharacteristic(
           this.useThermostat ? this.platform.Characteristic.CurrentHeatingCoolingState : this.platform.Characteristic.CurrentHeaterCoolerState,
           this.getCurrentState(),
         );
-        this.service.updateCharacteristic(
+        this.service?.updateCharacteristic(
           this.useThermostat ? this.platform.Characteristic.TargetHeatingCoolingState : this.platform.Characteristic.TargetHeaterCoolerState,
           this.getTargetState(),
         );
         if (!this.useThermostat) {
-          this.service.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
-          this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
+          this.service?.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
+          this.service?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
         }
         this.fanOnlyService?.updateCharacteristic(this.platform.Characteristic.On, this.getFanOnlyMode());
         this.fanService?.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
         this.fanService?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
+        this.fanService?.updateCharacteristic(this.platform.Characteristic.TargetFanState, this.getFanState());
         this.fanAutoService?.updateCharacteristic(this.platform.Characteristic.On, this.getFanState());
         this.dryModeService?.updateCharacteristic(this.platform.Characteristic.On, this.getDryMode());
         this.displayService?.updateCharacteristic(this.platform.Characteristic.On, this.getDisplayActive());
@@ -576,7 +929,20 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
         this.breezeAwayService?.updateCharacteristic(this.platform.Characteristic.On, this.getBreezeAway());
         this.auxService?.updateCharacteristic(this.platform.Characteristic.On, this.getAux());
         this.auxHeatingService?.updateCharacteristic(this.platform.Characteristic.On, this.getAuxHeating());
+        this.rateSelectService?.updateCharacteristic(this.platform.Characteristic.On, this.getRateSelectOn());
+        this.coolModeService?.updateCharacteristic(this.platform.Characteristic.On, this.getCoolMode());
+        this.heatModeService?.updateCharacteristic(this.platform.Characteristic.On, this.getHeatMode());
+        this.autoModeService?.updateCharacteristic(this.platform.Characteristic.On, this.getAutoMode());
+        this.selfCleanService?.updateCharacteristic(this.platform.Characteristic.On, this.getSelfCleanState());
+        this.smartEyeService?.updateCharacteristic(this.platform.Characteristic.On, this.getSmartEye());
+        this.audioFeedbackService?.updateCharacteristic(this.platform.Characteristic.On, this.getAudioFeedback());
       }
+    }
+
+    // Add history entry if any of the monitored attributes changed
+    if (Object.keys(historyEntry).length > 0) {
+      historyEntry.time = Math.round(new Date().getTime() / 1000);
+      this.historyService?.addEntry(historyEntry);
     }
   }
 
@@ -773,7 +1139,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getFanOnlyMode(): CharacteristicValue {
-    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.FAN_ONLY;
+    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.FAN_ONLY && !this.device.attributes.SELF_CLEAN;
   }
 
   async setFanOnlyMode(value: CharacteristicValue) {
@@ -785,7 +1151,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getFanState(): CharacteristicValue {
-    return this.device.attributes.FAN_SPEED === AUTO_FAN_SPEED;
+    return this.device.attributes.FAN_SPEED === AUTO_FAN_SPEED
+      ? this.platform.Characteristic.TargetFanState.AUTO
+      : this.platform.Characteristic.TargetFanState.MANUAL;
   }
 
   async setFanState(value: CharacteristicValue) {
@@ -803,11 +1171,11 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
     if (heating === this.heatingThresholdTemperature && cooling === this.coolingThresholdTemperature) return;
 
-    this.heatingThresholdTemperature = !thresholds?.cooling || heating < cooling ? heating : cooling - tempStep;
-    this.coolingThresholdTemperature = !thresholds?.heating || heating < cooling ? cooling : heating + tempStep;
+    this.heatingThresholdTemperature = limitValue(!thresholds?.cooling || heating < cooling ? heating : cooling - tempStep, minTemp, maxTemp);
+    this.coolingThresholdTemperature = limitValue(!thresholds?.heating || heating < cooling ? cooling : heating + tempStep, minTemp, maxTemp);
 
-    this.service.updateCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature, this.getHeatingThresholdTemperature());
-    this.service.updateCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature, this.getCoolingThresholdTemperature());
+    this.service?.updateCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature, this.getHeatingThresholdTemperature());
+    this.service?.updateCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature, this.getCoolingThresholdTemperature());
 
     const { context: ctx } = this.accessory;
     ctx.thresholds ??= {};
@@ -848,15 +1216,110 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getRotationSpeed(): CharacteristicValue {
-    return Math.min(100, this.device.attributes.FAN_SPEED ?? 0);
+    return limitValue(this.device.attributes.FAN_SPEED ?? 0, 0, 100);
   }
 
   async setRotationSpeed(value: CharacteristicValue) {
+    if (this.device.attributes.MODE === ACMode.AUTO) {
+      this.platform.log.debug(`[${this.device.name}] Ignoring fan speed change because AC is in Auto mode`);
+      // Update the characteristic back to the device value to reflect that it didn't change
+      setTimeout(() => {
+        this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
+        this.fanService?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getRotationSpeed());
+      }, 100);
+      return;
+    }
+    // If setting a specific speed, we disable auto fan state
     await this.device.set_attribute({ FAN_SPEED: value as number });
   }
 
+  private getFanSpeedSteps(): number[] {
+    const mode = this.configDev.AC_options.fanSpeedMode;
+    if (mode === '3') {
+      return [33, 66, 100];
+    } else if (mode === '5') {
+      return [20, 40, 60, 80, 100, AUTO_FAN_SPEED];
+    }
+    return [];
+  }
+
   getIndoorHumidity(): CharacteristicValue {
-    return this.device.attributes.INDOOR_HUMIDITY ?? 0;
+    let humidity = this.device.attributes.INDOOR_HUMIDITY;
+    this.platform.log.debug(`[${this.device.name}] getIndoorHumidity: Device reports ${humidity}% (Fallback enabled: ${this.configDev.AC_options.humidityWeatherFallback})`);
+    if (humidity === undefined || humidity === 0 || humidity === 255) {
+      if (this.configDev.AC_options.humidityWeatherFallback) {
+        if (this.platform.weatherService.humidity !== undefined) {
+          this.platform.log.info(`[${this.device.name}] Indoor humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`);
+          humidity = this.platform.weatherService.humidity;
+        } else {
+          this.platform.log.warn(`[${this.device.name}] Indoor humidity is invalid (${humidity}%) and weather fallback is enabled but no weather data is available yet.`);
+        }
+      } else if (humidity === 0 && this.platform.platformConfig.weather.enabled && !this.accessory.context.fallbackSuggested) {
+        this.platform.log.info(`[${this.device.name}] Device reports 0% humidity. If this is incorrect, enable "Humidity Weather Fallback" in settings to use local weather data.`);
+        this.accessory.context.fallbackSuggested = true;
+      }
+    }
+    const result = humidity ?? 0;
+    this.platform.log.debug(`[${this.device.name}] getIndoorHumidity returning ${result}%`);
+    return result;
+  }
+
+  getRealtimePower(): CharacteristicValue {
+    // Some characteristics have minimum values (e.g. CurrentAmbientLightLevel must be at least 0.0001)
+    const power = this.device.attributes.REALTIME_POWER ?? 0;
+    if (this.configDev.AC_options.powerDisplayType === 'Lux') {
+      return Math.max(power, 0.0001);
+    }
+    return power;
+  }
+
+  private getDisplayServiceType(type: string): any {
+    switch (type) {
+      case 'Humidity':
+        return this.platform.Service.HumiditySensor;
+      case 'CarbonDioxide':
+        return this.platform.Service.CarbonDioxideSensor;
+      case 'Temperature':
+        return this.platform.Service.TemperatureSensor;
+      default:
+        return this.platform.Service.LightSensor;
+    }
+  }
+
+  private getDisplayCharacteristic(type: string): any {
+    switch (type) {
+      case 'Humidity':
+        return this.platform.Characteristic.CurrentRelativeHumidity;
+      case 'CarbonDioxide':
+        return this.platform.Characteristic.CarbonDioxideLevel;
+      case 'Temperature':
+        return this.platform.Characteristic.CurrentTemperature;
+      default:
+        return this.platform.Characteristic.CurrentAmbientLightLevel;
+    }
+  }
+
+  private getDisplayUnit(type: string): string {
+    switch (type) {
+      case 'Humidity':
+        return '%';
+      case 'CarbonDioxide':
+        return 'ppm';
+      case 'Temperature':
+        return '°C';
+      case 'Lux':
+        return 'lux';
+      default:
+        return '';
+    }
+  }
+
+  getTotalEnergyConsumption(): CharacteristicValue {
+    const current = this.device.attributes.TOTAL_ENERGY_CONSUMPTION ?? 0;
+    if (current > (this.accessory.context.energy ?? 0)) {
+      this.accessory.context.energy = current;
+    }
+    return this.accessory.context.energy ?? 0;
   }
 
   getOutdoorTemperature(): CharacteristicValue {
@@ -865,6 +1328,12 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   getDisplayActive(): CharacteristicValue {
     return this.device.attributes.SCREEN_DISPLAY === true;
+  }
+
+  getFilterChangeIndication(): CharacteristicValue {
+    return this.device.attributes.FULL_DUST
+      ? this.platform.Characteristic.FilterChangeIndication.CHANGE_FILTER
+      : this.platform.Characteristic.FilterChangeIndication.FILTER_OK;
   }
 
   async setDisplayActive(value: CharacteristicValue) {
@@ -890,7 +1359,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getDryMode(): CharacteristicValue {
-    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.DRY;
+    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.DRY && !this.device.attributes.SELF_CLEAN;
   }
 
   async setDryMode(value: CharacteristicValue) {
@@ -914,14 +1383,14 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   getAux(): CharacteristicValue {
-    return this.device.attributes.POWER === true && this.device.attributes.SMART_EYE === true;
+    return this.device.attributes.POWER === true && this.device.attributes.AUX_HEATING === true;
   }
 
   async setAux(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ SMART_EYE: true });
+      await this.device.set_attribute({ AUX_HEATING: true });
     } else {
-      await this.device.set_attribute({ SMART_EYE: false });
+      await this.device.set_attribute({ AUX_HEATING: false });
     }
   }
 
@@ -942,7 +1411,13 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setSelfCleanState(value: CharacteristicValue) {
-    await this.device.set_self_clean(value === true);
+    if (value) {
+      this.platform.log.info(`[${this.device.name}] Activating Self-cleaning mode`);
+      // When activating self-clean, we ensure other modes are visually off
+      await this.device.set_self_clean(true);
+    } else {
+      await this.device.set_self_clean(false);
+    }
   }
 
   getIonState(): CharacteristicValue {
@@ -961,12 +1436,62 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     await this.device.set_out_silent(!!value);
   }
 
+  getRateSelectOn(): CharacteristicValue {
+    const value = this.device.attributes.RATE_SELECT;
+    return this.device.attributes.POWER === true && value !== 0 && value !== 100 && value !== undefined;
+  }
+
+  async setRateSelectOn(value: CharacteristicValue) {
+    if (value) {
+      if (this.device.attributes.POWER !== true) {
+        await this.device.set_attribute({ POWER: true });
+      }
+      if (this.getRateSelect() === 100) {
+        await this.device.set_rate_select(2); // 50%
+      }
+    } else {
+      await this.device.set_rate_select(0); // 100% (No limit)
+    }
+  }
+
   getRateSelect(): CharacteristicValue {
-    return this.device.attributes.RATE_SELECT ?? 100;
+    const value = this.device.attributes.RATE_SELECT;
+    if (value === 3 || value === 25) {
+      return 25;
+    } else if (value === 2 || value === 50) {
+      return 50;
+    } else if (value === 1 || value === 75) {
+      return 75;
+    } else if (value === 0 || value === 100) {
+      return 100;
+    } else if (value !== undefined && value > 0 && value <= 100) {
+      return value;
+    } else {
+      return 100;
+    }
   }
 
   async setRateSelect(value: CharacteristicValue) {
-    await this.device.set_rate_select(value as number);
+    const val = value as number;
+    let code = 0;
+    // Standard codes mapping
+    if (val === 25) {
+      code = 3;
+    } else if (val === 50) {
+      code = 2;
+    } else if (val === 75) {
+      code = 1;
+    } else if (val === 100 || val === 0) {
+      code = 0;
+    } else {
+      code = val;
+    }
+
+    // Try to support literal values if the device seems to use them
+    if (val > 3 && (this.device.attributes.RATE_SELECT === undefined || this.device.attributes.RATE_SELECT > 3)) {
+      code = val;
+    }
+    await this.device.set_rate_select(code);
   }
 
   getSwingAngleCurrentPosition(): CharacteristicValue {
@@ -1037,5 +1562,109 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     } else {
       await this.device.set_attribute({ COMFORT_MODE: false });
     }
+  }
+
+  getCoolMode(): CharacteristicValue {
+    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.COOLING && !this.device.attributes.SELF_CLEAN;
+  }
+
+  async setCoolMode(value: CharacteristicValue) {
+    if (value) {
+      await this.device.set_attribute({ POWER: true, MODE: ACMode.COOLING });
+    } else {
+      await this.device.set_attribute({ POWER: false });
+    }
+  }
+
+  getHeatMode(): CharacteristicValue {
+    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.HEATING && !this.device.attributes.SELF_CLEAN;
+  }
+
+  async setHeatMode(value: CharacteristicValue) {
+    if (value) {
+      await this.device.set_attribute({ POWER: true, MODE: ACMode.HEATING });
+    } else {
+      await this.device.set_attribute({ POWER: false });
+    }
+  }
+
+  getAutoMode(): CharacteristicValue {
+    return this.device.attributes.POWER === true && this.device.attributes.MODE === ACMode.AUTO && !this.device.attributes.SELF_CLEAN;
+  }
+
+  async setAutoMode(value: CharacteristicValue) {
+    if (value) {
+      await this.device.set_attribute({ POWER: true, MODE: ACMode.AUTO });
+    } else {
+      await this.device.set_attribute({ POWER: false });
+    }
+  }
+
+  getSmartEye(): CharacteristicValue {
+    return this.device.attributes.POWER === true && this.device.attributes.SMART_EYE === true;
+  }
+
+  async setSmartEye(value: CharacteristicValue) {
+    await this.device.set_attribute({ SMART_EYE: !!value });
+  }
+
+  getAudioFeedback(): CharacteristicValue {
+    return this.device.attributes.PROMPT_TONE === true;
+  }
+
+  async setAudioFeedback(value: CharacteristicValue) {
+    this.device.attributes.PROMPT_TONE = !!value;
+    await this.device.set_attribute({ PROMPT_TONE: !!value });
+  }
+
+  getTimerActive(): CharacteristicValue {
+    return this.timerEnd !== undefined && this.timerEnd > Date.now() ? 1 : 0;
+  }
+
+  async setTimerActive(value: CharacteristicValue) {
+    if (value === 1) {
+      // Start timer with default duration if not already set
+      const duration = (this.timerService?.getCharacteristic(this.platform.Characteristic.SetDuration).value as number) || 3600;
+      await this.setTimerDuration(duration);
+    } else {
+      // Stop timer
+      if (this.timerTimeout) {
+        clearTimeout(this.timerTimeout);
+        this.timerTimeout = undefined;
+      }
+      this.timerEnd = undefined;
+      this.timerService?.updateCharacteristic(this.platform.Characteristic.Active, 0);
+      this.timerService?.updateCharacteristic(this.platform.Characteristic.InUse, 0);
+      this.timerService?.updateCharacteristic(this.platform.Characteristic.RemainingDuration, 0);
+    }
+  }
+
+  async setTimerDuration(value: CharacteristicValue) {
+    const duration = value as number; // in seconds
+    this.timerEnd = Date.now() + duration * 1000;
+    if (this.timerTimeout) {
+      clearTimeout(this.timerTimeout);
+    }
+    this.timerTimeout = setTimeout(async () => {
+      this.platform.log.info(`[${this.device.name}] Timer expired, turning off AC`);
+      await this.device.set_attribute({ POWER: false });
+      this.timerEnd = undefined;
+      this.timerTimeout = undefined;
+      this.timerService?.updateCharacteristic(this.platform.Characteristic.Active, 0);
+      this.timerService?.updateCharacteristic(this.platform.Characteristic.InUse, 0);
+      this.timerService?.updateCharacteristic(this.platform.Characteristic.RemainingDuration, 0);
+    }, duration * 1000);
+
+    this.timerService?.updateCharacteristic(this.platform.Characteristic.Active, 1);
+    this.timerService?.updateCharacteristic(this.platform.Characteristic.InUse, 1);
+    this.timerService?.updateCharacteristic(this.platform.Characteristic.RemainingDuration, duration);
+  }
+
+  getTimerRemainingDuration(): CharacteristicValue {
+    if (this.timerEnd === undefined) {
+      return 0;
+    }
+    const remaining = Math.max(0, Math.floor((this.timerEnd - Date.now()) / 1000));
+    return remaining;
   }
 }

--- a/src/accessory/BaseAccessory.ts
+++ b/src/accessory/BaseAccessory.ts
@@ -28,25 +28,33 @@ export default abstract class BaseAccessory<T extends MideaDevice> {
 
     // Register a callback function with MideaDevice and then refresh device status.  The callback
     // is called whenever there is a change in any attribute value from the device.
-    this.device.on('update', this.updateCharacteristics.bind(this));
+    this.device.on('update', (attributes: DeviceAttributeBase) => {
+      if (this.initialized) {
+        this.updateCharacteristics(attributes);
+      }
+    });
     this.device.on('error_refresh', () => {
-      this.service.updateCharacteristic(this.platform.Characteristic.Active, new Error('Error refreshing device status'));
+      if (this.initialized) {
+        this.service.updateCharacteristic(this.platform.Characteristic.Active, new Error('Error refreshing device status'));
+      }
     });
   }
 
-  handleConfiguredName(service: Service, subtype: string, fallbackName: string) {
-    service
-      .getCharacteristic(this.platform.Characteristic.ConfiguredName)
-      .onGet(() => this.accessory.context.configuredNames[subtype] ?? `${this.device.name} ${fallbackName}`)
-      .onSet((value) => {
-        this.accessory.context.configuredNames[subtype] = value as string;
-      });
+  protected initialized = false;
+
+  handleConfiguredName(service: Service, subtype: string, fallbackName: string, customName?: string) {
+    const name = customName || `${this.device.name} ${fallbackName}`;
+    service.setCharacteristic(this.platform.Characteristic.Name, name);
   }
 
   // protected abstract handleErrorRefresh(): void;
   protected abstract updateCharacteristics(attributes: DeviceAttributeBase): Promise<void>;
 }
 
-export function limitValue(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(value, max));
+export function limitValue(value: any, min: number, max: number): number {
+  const n = Number(value);
+  if (Number.isNaN(n)) {
+    return min;
+  }
+  return Math.max(min, Math.min(n, max));
 }

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -206,7 +206,9 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
           this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
         }
         if (this.humiditySensorService) {
-          this.platform.log.info(`[${this.device.name}] Updating HumiditySensor service (iid: ${this.humiditySensorService.iid}) characteristic to ${humidity}%`);
+          this.platform.log.info(
+            `[${this.device.name}] Updating HumiditySensor service (iid: ${this.humiditySensorService.iid}) characteristic to ${humidity}%`,
+          );
           this.humiditySensorService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
         }
         this.historyService?.addEntry({ time: Math.round(new Date().getTime() / 1000), humidity: humidity as number });
@@ -225,7 +227,9 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
         this.platform.log.info(`[${this.device.name}] Humidity weather fallback enabled, waiting for first weather update.`);
       }
     } else if (this.platform.platformConfig.weather.enabled && this.configDev.A1_options.humiditySensor) {
-      this.platform.log.info(`[${this.device.name}] Tip: Global Weather Service is enabled. To use it as a fallback for this device, enable "Humidity Weather Fallback" in this device's settings.`);
+      this.platform.log.info(
+        `[${this.device.name}] Tip: Global Weather Service is enabled. To use it as a fallback for this device, enable "Humidity Weather Fallback" in this device's settings.`,
+      );
     }
   }
 
@@ -370,17 +374,25 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
   // Handle requests to get the current value of the "RelativeHumidity" characteristic
   private getCurrentRelativeHumidity(): CharacteristicValue {
     let humidity = this.device.attributes.CURRENT_HUMIDITY;
-    this.platform.log.debug(`[${this.device.name}] getCurrentRelativeHumidity: Device reports ${humidity}% (Fallback enabled: ${this.configDev.A1_options.humidityWeatherFallback})`);
+    this.platform.log.debug(
+      `[${this.device.name}] getCurrentRelativeHumidity: Device reports ${humidity}% (Fallback enabled: ${this.configDev.A1_options.humidityWeatherFallback})`,
+    );
     if (humidity === undefined || humidity === 0 || humidity === 255) {
       if (this.configDev.A1_options.humidityWeatherFallback) {
         if (this.platform.weatherService.humidity !== undefined) {
-          this.platform.log.info(`[${this.device.name}] Current humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`);
+          this.platform.log.info(
+            `[${this.device.name}] Current humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`,
+          );
           humidity = this.platform.weatherService.humidity;
         } else {
-          this.platform.log.warn(`[${this.device.name}] Current humidity is invalid (${humidity}%) and weather fallback is enabled but no weather data is available yet.`);
+          this.platform.log.warn(
+            `[${this.device.name}] Current humidity is invalid (${humidity}%) and weather fallback is enabled but no weather data is available yet.`,
+          );
         }
       } else if (humidity === 0 && this.platform.platformConfig.weather.enabled && !this.accessory.context.fallbackSuggested) {
-        this.platform.log.info(`[${this.device.name}] Device reports 0% humidity. If this is incorrect, enable "Humidity Weather Fallback" in settings to use local weather data.`);
+        this.platform.log.info(
+          `[${this.device.name}] Device reports 0% humidity. If this is incorrect, enable "Humidity Weather Fallback" in settings to use local weather data.`,
+        );
         this.accessory.context.fallbackSuggested = true;
       }
     }

--- a/src/accessory/DehumidifierAccessory.ts
+++ b/src/accessory/DehumidifierAccessory.ts
@@ -10,6 +10,8 @@
  *
  */
 import type { CharacteristicValue, Service } from 'homebridge';
+// @ts-ignore
+import FakegatoHistory from 'fakegato-history';
 import type MideaA1Device from '../devices/a1/MideaA1Device.js';
 import type { A1Attributes } from '../devices/a1/MideaA1Device.js';
 import type { MideaAccessory, MideaPlatform } from '../platform.js';
@@ -32,6 +34,7 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
   private pumpService?: Service;
   private waterTankContactService?: Service;
   private waterTankLeakService?: Service;
+  private historyService?: any;
   // Increment this every time we make a change to accessory that requires
   // previously cached Homebridge service to be deleted/replaced.
   private serviceVersion = 1;
@@ -183,6 +186,47 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
         this.waterTankLeakService = undefined;
       }
     }
+
+    this.initialized = true;
+
+    // Eve History
+    const FakeGatoHistoryService = FakegatoHistory(this.platform.api);
+    this.historyService = new FakeGatoHistoryService('weather', this.accessory, {
+      storage: 'fs',
+      log: this.platform.log,
+    });
+
+    // Weather Service updates
+    this.platform.weatherService.on('update', (data) => {
+      if (this.configDev.A1_options.humidityWeatherFallback) {
+        this.platform.log.info(`[${this.device.name}] Weather service updated (${data.humidity}%), refreshing humidity characteristic.`);
+        const humidity = this.getCurrentRelativeHumidity();
+        if (this.service) {
+          this.platform.log.info(`[${this.device.name}] Updating Dehumidifier service (iid: ${this.service.iid}) characteristic to ${humidity}%`);
+          this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        }
+        if (this.humiditySensorService) {
+          this.platform.log.info(`[${this.device.name}] Updating HumiditySensor service (iid: ${this.humiditySensorService.iid}) characteristic to ${humidity}%`);
+          this.humiditySensorService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        }
+        this.historyService?.addEntry({ time: Math.round(new Date().getTime() / 1000), humidity: humidity as number });
+      }
+    });
+
+    // Initial weather fallback check
+    if (this.configDev.A1_options.humidityWeatherFallback) {
+      this.platform.log.info(`[${this.device.name}] Humidity weather fallback enabled.`);
+      if (this.platform.weatherService.humidity !== undefined) {
+        const humidity = this.getCurrentRelativeHumidity();
+        this.platform.log.info(`[${this.device.name}] Using initial weather fallback humidity: ${humidity}%`);
+        this.service?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+        this.humiditySensorService?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+      } else {
+        this.platform.log.info(`[${this.device.name}] Humidity weather fallback enabled, waiting for first weather update.`);
+      }
+    } else if (this.platform.platformConfig.weather.enabled && this.configDev.A1_options.humiditySensor) {
+      this.platform.log.info(`[${this.device.name}] Tip: Global Weather Service is enabled. To use it as a fallback for this device, enable "Humidity Weather Fallback" in this device's settings.`);
+    }
   }
 
   /*********************************************************************
@@ -190,6 +234,7 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
    * any attribute value.
    */
   protected async updateCharacteristics(attributes: Partial<A1Attributes>) {
+    let historyEntry: any = {};
     for (const [k, v] of Object.entries(attributes)) {
       this.platform.log.debug(`[${this.device.name}] Set attribute ${k} to: ${v}`);
       let updateState = false;
@@ -198,27 +243,31 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
           updateState = true;
           break;
         case 'target_humidity':
-          this.service.updateCharacteristic(this.platform.Characteristic.RelativeHumidityDehumidifierThreshold, v as CharacteristicValue);
+          this.service?.updateCharacteristic(this.platform.Characteristic.RelativeHumidityDehumidifierThreshold, v as CharacteristicValue);
           updateState = true;
           break;
         case 'fan_speed':
-          this.service.updateCharacteristic(this.platform.Characteristic.RotationSpeed, v as CharacteristicValue);
+          this.service?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, v as CharacteristicValue);
           this.fanService?.updateCharacteristic(this.platform.Characteristic.RotationSpeed, v as CharacteristicValue);
           updateState = true;
           break;
-        case 'current_humidity':
-          this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, v as CharacteristicValue);
-          this.humiditySensorService?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, v as CharacteristicValue);
+        case 'current_humidity': {
+          const humidity = this.getCurrentRelativeHumidity();
+          this.service?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+          this.humiditySensorService?.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, humidity);
+          historyEntry.humidity = humidity as number;
           updateState = true;
           break;
+        }
         case 'mode':
           updateState = true;
           break;
         case 'current_temperature':
           this.temperatureService?.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, v as CharacteristicValue);
+          historyEntry.temp = v as number;
           break;
         case 'tank_level':
-          this.service.updateCharacteristic(this.platform.Characteristic.WaterLevel, v as CharacteristicValue);
+          this.service?.updateCharacteristic(this.platform.Characteristic.WaterLevel, v as CharacteristicValue);
           break;
         case 'pump':
           this.pumpService?.updateCharacteristic(this.platform.Characteristic.On, v as CharacteristicValue);
@@ -240,14 +289,20 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
           this.platform.log.debug(`[${this.device.name}] Attempt to set unsupported attribute ${k} to ${v}`);
       }
       if (updateState) {
-        this.service.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
-        this.service.updateCharacteristic(
+        this.service?.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
+        this.service?.updateCharacteristic(
           this.platform.Characteristic.TargetHumidifierDehumidifierState,
           this.platform.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER,
         );
-        this.service.updateCharacteristic(this.platform.Characteristic.CurrentHumidifierDehumidifierState, this.currentHumidifierDehumidifierState());
+        this.service?.updateCharacteristic(this.platform.Characteristic.CurrentHumidifierDehumidifierState, this.currentHumidifierDehumidifierState());
         this.fanService?.updateCharacteristic(this.platform.Characteristic.Active, this.getActive());
       }
+    }
+
+    // Add history entry if any of the monitored attributes changed
+    if (Object.keys(historyEntry).length > 0) {
+      historyEntry.time = Math.round(new Date().getTime() / 1000);
+      this.historyService?.addEntry(historyEntry);
     }
   }
 
@@ -314,12 +369,29 @@ export default class DehumidifierAccessory extends BaseAccessory<MideaA1Device> 
 
   // Handle requests to get the current value of the "RelativeHumidity" characteristic
   private getCurrentRelativeHumidity(): CharacteristicValue {
+    let humidity = this.device.attributes.CURRENT_HUMIDITY;
+    this.platform.log.debug(`[${this.device.name}] getCurrentRelativeHumidity: Device reports ${humidity}% (Fallback enabled: ${this.configDev.A1_options.humidityWeatherFallback})`);
+    if (humidity === undefined || humidity === 0 || humidity === 255) {
+      if (this.configDev.A1_options.humidityWeatherFallback) {
+        if (this.platform.weatherService.humidity !== undefined) {
+          this.platform.log.info(`[${this.device.name}] Current humidity is invalid (${humidity}%), using weather fallback: ${this.platform.weatherService.humidity}%`);
+          humidity = this.platform.weatherService.humidity;
+        } else {
+          this.platform.log.warn(`[${this.device.name}] Current humidity is invalid (${humidity}%) and weather fallback is enabled but no weather data is available yet.`);
+        }
+      } else if (humidity === 0 && this.platform.platformConfig.weather.enabled && !this.accessory.context.fallbackSuggested) {
+        this.platform.log.info(`[${this.device.name}] Device reports 0% humidity. If this is incorrect, enable "Humidity Weather Fallback" in settings to use local weather data.`);
+        this.accessory.context.fallbackSuggested = true;
+      }
+    }
     this.platform.log.debug(
-      `[${this.device.name}] GET CurrentRelativeHumidity, value: ${this.device.attributes.CURRENT_HUMIDITY},\
+      `[${this.device.name}] GET CurrentRelativeHumidity, value: ${humidity},\
                                                                    custom offset: ${this.configDev.A1_options.humidityOffset}`,
     );
+    const result = (humidity ?? 0) + this.configDev.A1_options.humidityOffset;
+    this.platform.log.debug(`[${this.device.name}] getCurrentRelativeHumidity returning ${result}%`);
     // Adding custom offset to the humidity value
-    return this.device.attributes.CURRENT_HUMIDITY + this.configDev.A1_options.humidityOffset;
+    return result;
   }
 
   // Handle requests to get the Relative value of the "HumidityDehumidifierThreshold" characteristic

--- a/src/accessory/DishwasherAccessory.ts
+++ b/src/accessory/DishwasherAccessory.ts
@@ -39,6 +39,8 @@ export default class DishwasherAccessory extends BaseAccessory<MideaE1Device> {
       .getCharacteristic(this.platform.Characteristic.RemainingDuration)
       .setProps({ minValue: 0, maxValue: 60 * 60 * 8, minStep: 1 })
       .onGet(this.getRemainingDuration.bind(this));
+
+    this.initialized = true;
   }
 
   async updateCharacteristics(attributes: Partial<E1Attributes>) {

--- a/src/accessory/ElectricWaterHeaterAccessory.ts
+++ b/src/accessory/ElectricWaterHeaterAccessory.ts
@@ -79,11 +79,13 @@ export default class ElectricWaterHeaterAccessory extends BaseAccessory<MideaE2D
       this.handleConfiguredName(this.wholeTankHeatingService, wholeTankHeatingSubtype, 'Whole Tank Heating');
       this.wholeTankHeatingService
         .getCharacteristic(this.platform.Characteristic.On)
-        .onGet(this.getWholeTankHeating.bind(this))
+        ?.onGet(this.getWholeTankHeating.bind(this))
         .onSet(this.setWholeTankHeating.bind(this));
     } else if (this.wholeTankHeatingService) {
       this.accessory.removeService(this.wholeTankHeatingService);
     }
+
+    this.initialized = true;
   }
 
   /*********************************************************************

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -45,8 +45,13 @@ export default abstract class MideaDevice extends EventEmitter {
   protected verbose: boolean;
   protected logRecoverableErrors: boolean;
   protected logRefreshStatusErrors: boolean;
+  protected refreshBeforeSet: boolean;
 
   private _sub_type?: number;
+  private pendingAttributes: DeviceAttributeBase = {};
+  private setAttributePromises: { resolve: () => void; reject: (err: any) => void }[] = [];
+  private setAttributeTimer: NodeJS.Timeout | null = null;
+  private isApplyingAttributes = false;
 
   public token: KeyToken = undefined;
   public key: KeyToken = undefined;
@@ -61,7 +66,62 @@ export default abstract class MideaDevice extends EventEmitter {
   protected abstract build_query(): MessageRequest[];
   protected abstract process_message(message: Buffer): void;
   protected abstract set_subtype(): void;
-  public abstract set_attribute(status: DeviceAttributeBase): Promise<void>;
+  protected abstract apply_attributes(attributes: DeviceAttributeBase): Promise<void>;
+
+  public async set_attribute(attributes: DeviceAttributeBase): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.logger.debug(`[${this.name}] Enqueuing attribute change: ${JSON.stringify(attributes)}`);
+      Object.assign(this.pendingAttributes, attributes);
+      this.setAttributePromises.push({ resolve, reject });
+
+      if (this.setAttributeTimer) {
+        clearTimeout(this.setAttributeTimer);
+      }
+
+      this.setAttributeTimer = setTimeout(async () => {
+        this.setAttributeTimer = null;
+        await this.processPendingAttributes();
+      }, 250); // 250ms debounce
+    });
+  }
+
+  private async processPendingAttributes() {
+    if (this.isApplyingAttributes) {
+      return;
+    }
+
+    if (Object.keys(this.pendingAttributes).length === 0) {
+      return;
+    }
+
+    this.isApplyingAttributes = true;
+    const attrs = { ...this.pendingAttributes };
+    const promises = [...this.setAttributePromises];
+    this.pendingAttributes = {};
+    this.setAttributePromises = [];
+
+    try {
+      this.logger.debug(`[${this.name}] Applying consolidated attributes: ${JSON.stringify(attrs)}`);
+      if (this.refreshBeforeSet) {
+        this.logger.debug(`[${this.name}] Refreshing status before set as requested in config`);
+        await this.refresh_status(true);
+      }
+      await this.apply_attributes(attrs);
+      promises.forEach((p) => p.resolve());
+    } catch (err) {
+      this.logger.error(`[${this.name}] Error applying attributes: ${err}`);
+      promises.forEach((p) => p.reject(err));
+    } finally {
+      this.isApplyingAttributes = false;
+      // If more attributes were added while we were processing, schedule another run
+      if (Object.keys(this.pendingAttributes).length > 0 && !this.setAttributeTimer) {
+        this.setAttributeTimer = setTimeout(async () => {
+          this.setAttributeTimer = null;
+          await this.processPendingAttributes();
+        }, 100);
+      }
+    }
+  }
 
   constructor(
     protected readonly logger: Logger,
@@ -86,6 +146,7 @@ export default abstract class MideaDevice extends EventEmitter {
     this.verbose = configDev.advanced_options.verbose;
     this.logRecoverableErrors = configDev.advanced_options.logRecoverableErrors;
     this.logRefreshStatusErrors = configDev.advanced_options.logRefreshStatusErrors;
+    this.refreshBeforeSet = configDev.advanced_options.refreshBeforeSet;
 
     this.logger.debug(`[${this.name}] Device specific verbose debug logging is set to ${configDev.advanced_options.verbose}`);
     this.logger.debug(`[${this.name}] Device specific log recoverable errors is set to ${configDev.advanced_options.logRecoverableErrors}`);
@@ -178,11 +239,15 @@ export default abstract class MideaDevice extends EventEmitter {
         }
       } else {
         this._authenticated = false;
-        throw Error(`Authenticate error when receiving data from ${this.ip}:${this.port}.`);
+        throw Error(`Authenticate error when receiving data from ${this.ip}:${this.port}. (No response)`);
       }
     } catch (err) {
       this._authenticated = false;
-      throw err;
+      const msg = err instanceof Error ? err.message : err;
+      throw new Error(
+        `Authentication failed: ${msg}. Hint: check if your token/key are still valid. If you recently removed the device from the Midea app, you may need to re-generate them.`,
+        { cause: err },
+      );
     }
   }
 
@@ -203,22 +268,27 @@ export default abstract class MideaDevice extends EventEmitter {
     }
     if (force_reinit || !this.promiseSocket || this.promiseSocket.destroyed) {
       this.promiseSocket = new PromiseSocket(this.logger, this.logRecoverableErrors);
-      let connected = await this.connect(false);
-      while (!connected) {
-        connected = await this.connect(false);
+      const connected = await this.connect(false);
+      if (!connected) {
+        throw new Error(`[${this.name}] Connection failed`);
       }
     }
     try {
       await this.promiseSocket.write(data);
-    } catch {
-      this.logger.debug(`[${this.name}] Error when sending data to device, retrying...`);
+    } catch (err) {
+      this.logger.debug(`[${this.name}] Error when sending data to device, retrying in 2s... (${retries} retries left): ${err}`);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       await this.send_message_v2(data, retries - 1, true);
     }
   }
 
   private async send_message_v3(data: Buffer, message_type: TCPMessageType = TCPMessageType.ENCRYPTED_REQUEST) {
     if (!this._authenticated) {
-      this.logger.warn(`[${this.name}] Cannot send V3 message — not authenticated. Dropping message.`);
+      this.logger.debug(`[${this.name}] Not authenticated, attempting to connect...`);
+      await this.connect(false);
+    }
+    if (!this._authenticated) {
+      this.logger.warn(`[${this.name}] Cannot send V3 message — authentication failed. Dropping message.`);
       return;
     }
     const encrypted_data = this.security.encode_8370(data, message_type);

--- a/src/core/MideaDiscover.ts
+++ b/src/core/MideaDiscover.ts
@@ -48,12 +48,18 @@ export default class Discover extends EventEmitter {
         // Only add device if it has not already been added.
         this.ips.push(rinfo.address);
 
-        const device_version = this.getDeviceVersion(msg);
-        const device_info = await this.getDeviceInfo(rinfo.address, device_version, msg);
-        this.logger.info(`Discovered device: ${JSON.stringify(device_info)}`);
+        try {
+          const device_version = this.getDeviceVersion(msg);
+          const device_info = await this.getDeviceInfo(rinfo.address, device_version, msg);
+          this.logger.info(`Discovered device: ${JSON.stringify(device_info)}`);
 
-        // Send signal to Homebridge platform with details on the discovered device
-        this.emit('device', device_info);
+          // Send signal to Homebridge platform with details on the discovered device
+          this.emit('device', device_info);
+        } catch (err) {
+          this.logger.error(`Error while processing discovery message from ${rinfo.address}: ${err}`);
+          // Remove from list so we can try again
+          this.ips = this.ips.filter((ip) => ip !== rinfo.address);
+        }
       }
     });
   }
@@ -115,7 +121,7 @@ export default class Discover extends EventEmitter {
       const msg = e instanceof Error ? e.stack : e;
       this.logger.error(`Fatal error during plugin initialization:\n${msg}`);
     }
-    // this.logger.info(`Broadcast addresses: ${JSON.stringify(list)}`);
+    this.logger.debug(`Broadcasting to: ${JSON.stringify(list)}`);
     return list;
   }
 
@@ -125,6 +131,7 @@ export default class Discover extends EventEmitter {
    * up to an additional "retries" times each spaced by 3 seconds.
    */
   public startDiscover(retries = 3, timeout = 2000) {
+    this.ips = [];
     let tries = 0;
     // force timeout to be between 500ms and 5 seconds
     const limitedTimeout = Math.max(500, Math.min(timeout, 5000));

--- a/src/core/WeatherService.ts
+++ b/src/core/WeatherService.ts
@@ -46,7 +46,9 @@ export class WeatherService extends EventEmitter {
       } else if (this.config.location && this.config.location.length > 2) {
         // Try geocoding
         this.log.debug(`Attempting geocoding for location: ${this.config.location}`);
-        const geoResponse = await axios.get(`https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(this.config.location)}&limit=1&appid=${this.config.apiKey}`);
+        const geoResponse = await axios.get(
+          `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(this.config.location)}&limit=1&appid=${this.config.apiKey}`,
+        );
         if (geoResponse.data && geoResponse.data.length > 0) {
           lat = geoResponse.data[0].lat;
           lon = geoResponse.data[0].lon;
@@ -69,20 +71,24 @@ export class WeatherService extends EventEmitter {
 
       this.log.debug(`Fetching weather for ${lat}, ${lon}...`);
       const weatherResponse = await axios.get(`https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${this.config.apiKey}&units=metric`);
-      
+
       if (weatherResponse.data && weatherResponse.data.main) {
         this._humidity = weatherResponse.data.main.humidity;
         this._temperature = weatherResponse.data.main.temp;
         if (this._humidity === 0) {
-          this.log.warn(`[WeatherService] Received 0% humidity from OpenWeatherMap for location ${lat}, ${lon}. This might be a temporary error or specific local condition.`);
+          this.log.warn(
+            `[WeatherService] Received 0% humidity from OpenWeatherMap for location ${lat}, ${lon}. This might be a temporary error or specific local condition.`,
+          );
         }
-        this.log.info(`Weather updated: Humidity ${this._humidity}%, Temperature ${this._temperature}°C (Location: ${weatherResponse.data.name || lat + ',' + lon})`);
+        this.log.info(
+          `Weather updated: Humidity ${this._humidity}%, Temperature ${this._temperature}°C (Location: ${weatherResponse.data.name || lat + ',' + lon})`,
+        );
         this.emit('update', { humidity: this._humidity, temperature: this._temperature });
       } else {
         throw new Error('Invalid response from OpenWeatherMap API.');
       }
     } catch (error) {
-      const msg = axios.isAxiosError(error) ? (error.response?.data?.message || error.message) : (error instanceof Error ? error.message : String(error));
+      const msg = axios.isAxiosError(error) ? error.response?.data?.message || error.message : error instanceof Error ? error.message : String(error);
       this.log.error(`[WeatherService] Failed to update weather: ${msg}`);
       if (msg.includes('Invalid API key')) {
         this.log.error('[WeatherService] Your OpenWeatherMap API key seems to be invalid or not yet active (it can take up to 2 hours after creation).');

--- a/src/core/WeatherService.ts
+++ b/src/core/WeatherService.ts
@@ -1,0 +1,98 @@
+import axios from 'axios';
+import { EventEmitter } from 'events';
+import type { Logger } from 'homebridge';
+import type { WeatherConfig } from '../platformUtils.js';
+
+export class WeatherService extends EventEmitter {
+  private _humidity: number | undefined;
+  private _temperature: number | undefined;
+  private timer: NodeJS.Timeout | undefined;
+
+  constructor(
+    private readonly log: Logger,
+    private readonly config: WeatherConfig,
+  ) {
+    super();
+    if (this.config.enabled && this.config.apiKey) {
+      this.start();
+    }
+  }
+
+  public get humidity(): number | undefined {
+    return this._humidity;
+  }
+
+  public get temperature(): number | undefined {
+    return this._temperature;
+  }
+
+  private async start() {
+    this.log.info('Weather Service starting...');
+    await this.updateWeather();
+    // Default interval in config is in minutes, convert to ms
+    const intervalMs = Math.max(this.config.interval, 5) * 60 * 1000;
+    this.timer = setInterval(() => this.updateWeather(), intervalMs);
+  }
+
+  private async updateWeather() {
+    try {
+      let lat: number, lon: number;
+
+      if (this.config.location && this.config.location.includes(',')) {
+        const parts = this.config.location.split(',');
+        lat = parseFloat(parts[0]);
+        lon = parseFloat(parts[1]);
+        this.log.debug(`Using manual location: ${lat}, ${lon}`);
+      } else if (this.config.location && this.config.location.length > 2) {
+        // Try geocoding
+        this.log.debug(`Attempting geocoding for location: ${this.config.location}`);
+        const geoResponse = await axios.get(`https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(this.config.location)}&limit=1&appid=${this.config.apiKey}`);
+        if (geoResponse.data && geoResponse.data.length > 0) {
+          lat = geoResponse.data[0].lat;
+          lon = geoResponse.data[0].lon;
+          this.log.info(`Geocoded "${this.config.location}" to ${lat}, ${lon} (${geoResponse.data[0].name}, ${geoResponse.data[0].country})`);
+        } else {
+          throw new Error(`Failed to geocode location: ${this.config.location}`);
+        }
+      } else {
+        // Get location by IP
+        this.log.debug('Attempting to determine location by IP...');
+        const geoResponse = await axios.get('http://ip-api.com/json/');
+        if (geoResponse.data && geoResponse.data.status === 'success') {
+          lat = geoResponse.data.lat;
+          lon = geoResponse.data.lon;
+          this.log.info(`Determined location by IP: ${lat}, ${lon} (${geoResponse.data.city}, ${geoResponse.data.country})`);
+        } else {
+          throw new Error(`Failed to determine location by IP: ${geoResponse.data?.message || 'Unknown error'}. Please provide a manual location.`);
+        }
+      }
+
+      this.log.debug(`Fetching weather for ${lat}, ${lon}...`);
+      const weatherResponse = await axios.get(`https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${this.config.apiKey}&units=metric`);
+      
+      if (weatherResponse.data && weatherResponse.data.main) {
+        this._humidity = weatherResponse.data.main.humidity;
+        this._temperature = weatherResponse.data.main.temp;
+        if (this._humidity === 0) {
+          this.log.warn(`[WeatherService] Received 0% humidity from OpenWeatherMap for location ${lat}, ${lon}. This might be a temporary error or specific local condition.`);
+        }
+        this.log.info(`Weather updated: Humidity ${this._humidity}%, Temperature ${this._temperature}°C (Location: ${weatherResponse.data.name || lat + ',' + lon})`);
+        this.emit('update', { humidity: this._humidity, temperature: this._temperature });
+      } else {
+        throw new Error('Invalid response from OpenWeatherMap API.');
+      }
+    } catch (error) {
+      const msg = axios.isAxiosError(error) ? (error.response?.data?.message || error.message) : (error instanceof Error ? error.message : String(error));
+      this.log.error(`[WeatherService] Failed to update weather: ${msg}`);
+      if (msg.includes('Invalid API key')) {
+        this.log.error('[WeatherService] Your OpenWeatherMap API key seems to be invalid or not yet active (it can take up to 2 hours after creation).');
+      }
+    }
+  }
+
+  public stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+  }
+}

--- a/src/devices/a1/MideaA1Device.ts
+++ b/src/devices/a1/MideaA1Device.ts
@@ -155,7 +155,7 @@ export default class MideaA1Device extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<A1Attributes>) {
+  protected async apply_attributes(attributes: Partial<A1Attributes>) {
     const messageToSend: {
       SET: MessageSet | undefined;
     } = {
@@ -184,13 +184,12 @@ export default class MideaA1Device extends MideaDevice {
         }
       }
 
-      for (const [k, v] of Object.entries(messageToSend)) {
+      for (const v of Object.values(messageToSend)) {
         if (v !== undefined) {
-          this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -497,7 +497,7 @@ export default class MideaACDevice extends MideaDevice {
         this.last_fan_speed = this.attributes.FAN_SPEED;
       }
     }
-    const fan_speed = fan_auto ? AUTO_FAN_SPEED : (this.last_fan_speed === AUTO_FAN_SPEED ? 80 : this.last_fan_speed);
+    const fan_speed = fan_auto ? AUTO_FAN_SPEED : this.last_fan_speed === AUTO_FAN_SPEED ? 80 : this.last_fan_speed;
     message.fan_speed = fan_speed;
     this.attributes.FAN_SPEED = fan_speed;
     this.attributes.FAN_AUTO = fan_auto;

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -111,10 +111,9 @@ export default class MideaACDevice extends MideaDevice {
   private power_analysis_method?: number;
 
   private alternate_switch_display = false;
-  private last_fan_speed = AUTO_FAN_SPEED; // default to Auto
+  private last_fan_speed = 80; // default to High when leaving auto
 
   private defaultFahrenheit: boolean;
-  private defaultScreenOff: boolean;
 
   /*********************************************************************
    * Constructor initializes all the attributes.  We set some to invalid
@@ -169,7 +168,6 @@ export default class MideaACDevice extends MideaDevice {
     };
 
     this.defaultFahrenheit = deviceConfig.AC_options.fahrenheit;
-    this.defaultScreenOff = deviceConfig.AC_options.screenOff;
   }
 
   build_query() {
@@ -215,6 +213,9 @@ export default class MideaACDevice extends MideaDevice {
     for (const status of Object.keys(this.attributes)) {
       const value = message.get_body_attribute(status.toLowerCase());
       if (value !== undefined) {
+        if (status === 'FAN_SPEED' && value !== AUTO_FAN_SPEED) {
+          this.last_fan_speed = value as number;
+        }
         if (this.attributes[status] !== value) {
           // Track only those attributes that change value.  So when we send to the Homebridge /
           // HomeKit accessory we only update values that change.  First time through this
@@ -401,9 +402,9 @@ export default class MideaACDevice extends MideaDevice {
             if (k === 'POWER' && v === true && messageToSend.GENERAL instanceof MessageGeneralSet) {
               messageToSend.GENERAL.temp_fahrenheit = this.defaultFahrenheit;
               this.attributes.TEMP_FAHRENHEIT = this.defaultFahrenheit;
-              if (this.defaultScreenOff) {
-                messageToSend.SWITCH_DISPLAY ??= new MessageSwitchDisplay(this.device_protocol_version);
-              }
+              // Always send prompt tone state when turning on
+              messageToSend.SWITCH_DISPLAY ??= new MessageSwitchDisplay(this.device_protocol_version);
+              messageToSend.SWITCH_DISPLAY.prompt_tone = this.attributes.PROMPT_TONE;
             }
             if (k === 'MODE') {
               // Reset dry flag when changing mode to avoid conflicts
@@ -492,9 +493,11 @@ export default class MideaACDevice extends MideaDevice {
 
     if (fan_auto) {
       // Save last fan speed before setting to auto
-      this.last_fan_speed = this.attributes.FAN_SPEED;
+      if (this.attributes.FAN_SPEED !== AUTO_FAN_SPEED) {
+        this.last_fan_speed = this.attributes.FAN_SPEED;
+      }
     }
-    const fan_speed = fan_auto ? AUTO_FAN_SPEED : this.last_fan_speed;
+    const fan_speed = fan_auto ? AUTO_FAN_SPEED : (this.last_fan_speed === AUTO_FAN_SPEED ? 80 : this.last_fan_speed);
     message.fan_speed = fan_speed;
     this.attributes.FAN_SPEED = fan_speed;
     this.attributes.FAN_AUTO = fan_auto;

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -306,16 +306,12 @@ export default class MideaACDevice extends MideaDevice {
     return this.used_subprotocol ? this.make_subprotocol_message_set() : this.make_message_set();
   }
 
-  async set_attribute(attributes: Partial<ACAttributes>) {
+  protected async apply_attributes(attributes: Partial<ACAttributes>) {
     const messageToSend: {
-      GENERAL: MessageGeneralSet | MessageSubProtocolSet | undefined;
-      NEW_PROTOCOL: MessageNewProtocolSet | undefined;
-      SWITCH_DISPLAY: MessageSwitchDisplay | undefined;
-    } = {
-      GENERAL: undefined,
-      NEW_PROTOCOL: undefined,
-      SWITCH_DISPLAY: undefined,
-    };
+      GENERAL?: MessageGeneralSet | MessageSubProtocolSet;
+      NEW_PROTOCOL?: MessageNewProtocolSet;
+      SWITCH_DISPLAY?: MessageSwitchDisplay;
+    } = {};
 
     try {
       for (const [k, v] of Object.entries(attributes)) {
@@ -393,6 +389,62 @@ export default class MideaACDevice extends MideaDevice {
           } else if (k === 'FAN_SPEED') {
             messageToSend.GENERAL ??= this.make_message_unique_set();
             this.set_fan_speed(v as number, messageToSend.GENERAL);
+            // Disable rate select (gear mode) when setting fan speed as they often conflict
+            if (this.attributes.RATE_SELECT !== undefined && this.attributes.RATE_SELECT !== 0 && this.attributes.RATE_SELECT !== 100) {
+              this.logger.debug(`[${this.name}] Disabling gear mode for manual fan speed`);
+              messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+              messageToSend.NEW_PROTOCOL.rate_select = 0;
+              this.attributes.RATE_SELECT = 0;
+            }
+          } else if (k === 'FAN_AUTO') {
+            messageToSend.GENERAL ??= this.make_message_unique_set();
+            if (v) {
+              if (this.attributes.FAN_SPEED !== AUTO_FAN_SPEED) {
+                this.last_fan_speed = this.attributes.FAN_SPEED;
+              }
+            }
+            const fanSpeed = v ? AUTO_FAN_SPEED : this.last_fan_speed === AUTO_FAN_SPEED ? 80 : (this.last_fan_speed ?? 80);
+            this.set_fan_speed(fanSpeed, messageToSend.GENERAL);
+          } else if (k === 'RATE_SELECT') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            messageToSend.NEW_PROTOCOL.rate_select = v as number;
+            this.attributes.RATE_SELECT = v as number;
+            messageToSend.NEW_PROTOCOL.prompt_tone = this.attributes.PROMPT_TONE;
+            // Force fan to auto when setting gear mode as they often conflict
+            if (v !== 0 && v !== 100) {
+              if (this.attributes.FAN_SPEED !== AUTO_FAN_SPEED) {
+                this.logger.debug(`[${this.name}] Forcing fan to auto for gear mode`);
+                messageToSend.GENERAL ??= this.make_message_unique_set();
+                if (this.attributes.FAN_SPEED !== AUTO_FAN_SPEED) {
+                  this.last_fan_speed = this.attributes.FAN_SPEED;
+                }
+                this.set_fan_speed(AUTO_FAN_SPEED, messageToSend.GENERAL);
+              }
+            } else if (this.last_fan_speed !== undefined && this.last_fan_speed !== AUTO_FAN_SPEED) {
+              this.logger.debug(`[${this.name}] Restoring fan speed to ${this.last_fan_speed} after disabling gear mode`);
+              messageToSend.GENERAL ??= this.make_message_unique_set();
+              this.set_fan_speed(this.last_fan_speed, messageToSend.GENERAL);
+            }
+          } else if (k === 'OUT_SILENT') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            messageToSend.NEW_PROTOCOL.out_silent = !!v;
+            this.attributes.OUT_SILENT = !!v;
+            messageToSend.NEW_PROTOCOL.prompt_tone = this.attributes.PROMPT_TONE;
+          } else if (k === 'SELF_CLEAN') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            messageToSend.NEW_PROTOCOL.self_clean = !!v;
+            this.attributes.SELF_CLEAN = !!v;
+            messageToSend.NEW_PROTOCOL.prompt_tone = this.attributes.PROMPT_TONE;
+          } else if (k === 'WIND_SWING_UD_ANGLE') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            messageToSend.NEW_PROTOCOL.wind_swing_ud_angle = v as number;
+            this.attributes.WIND_SWING_UD_ANGLE = v as number;
+            messageToSend.NEW_PROTOCOL.prompt_tone = this.attributes.PROMPT_TONE;
+          } else if (k === 'WIND_SWING_LR_ANGLE') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            messageToSend.NEW_PROTOCOL.wind_swing_lr_angle = v as number;
+            this.attributes.WIND_SWING_LR_ANGLE = v as number;
+            messageToSend.NEW_PROTOCOL.prompt_tone = this.attributes.PROMPT_TONE;
           } else if (this.FAN_RELATED_MODES.includes(k)) {
             messageToSend.GENERAL ??= this.make_message_unique_set();
             this.set_fan_related_mode(k, v as boolean, messageToSend.GENERAL);
@@ -417,13 +469,17 @@ export default class MideaACDevice extends MideaDevice {
           this.logger.debug(`[${this.name}] Tried to set ${k} to: ${v}, but it's not allowed.`);
         }
       }
-      for (const [k, v] of Object.entries(messageToSend)) {
+      const messageOrder: (keyof typeof messageToSend)[] = ['NEW_PROTOCOL', 'GENERAL', 'SWITCH_DISPLAY'];
+      for (const type of messageOrder) {
+        const v = messageToSend[type];
         if (v !== undefined) {
-          this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
+          this.logger.debug(`[${this.name}] Set message ${type}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
+          // Add a small delay between messages to ensure device processes them correctly
+          await new Promise((resolve) => setTimeout(resolve, 50));
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);
@@ -435,30 +491,16 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_target_temperature(target_temperature: number, mode?: number) {
-    this.logger.info(`[${this.name}] Set target temperature to: ${target_temperature}`);
-    const message = this.make_message_unique_set();
-    message.target_temperature = target_temperature;
-    this.attributes.TARGET_TEMPERATURE = target_temperature;
-    if (mode) {
-      message.mode = mode;
-      message.power = true;
-
-      this.attributes.MODE = mode;
-      this.attributes.POWER = true;
+    const attributes: Partial<ACAttributes> = { TARGET_TEMPERATURE: target_temperature };
+    if (mode !== undefined) {
+      attributes.MODE = mode;
+      attributes.POWER = true;
     }
-    await this.build_send(message);
+    await this.set_attribute(attributes);
   }
 
   async set_swing(swing_horizontal: boolean, swing_vertical: boolean) {
-    this.logger.info(`[${this.name}] Set swing horizontal to: ${swing_horizontal}, vertical to: ${swing_vertical}`);
-    const message = this.make_message_set();
-    message.swing_horizontal = swing_horizontal;
-    message.swing_vertical = swing_vertical;
-    this.attributes.SWING_HORIZONTAL = swing_horizontal;
-    this.attributes.SWING_VERTICAL = swing_vertical;
-    this.attributes.WIND_SWING_LR_ANGLE = 0;
-    this.attributes.WIND_SWING_UD_ANGLE = 0;
-    await this.build_send(message);
+    await this.set_attribute({ SWING_HORIZONTAL: swing_horizontal, SWING_VERTICAL: swing_vertical });
   }
 
   private disable_all_fan_related_modes(message: MessageGeneralSet | MessageSubProtocolSet) {
@@ -486,22 +528,7 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_fan_auto(fan_auto: boolean) {
-    this.logger.info(`[${this.name}] Set fan auto to: ${fan_auto}`);
-    const message = this.make_message_unique_set();
-
-    this.disable_all_fan_related_modes(message);
-
-    if (fan_auto) {
-      // Save last fan speed before setting to auto
-      if (this.attributes.FAN_SPEED !== AUTO_FAN_SPEED) {
-        this.last_fan_speed = this.attributes.FAN_SPEED;
-      }
-    }
-    const fan_speed = fan_auto ? AUTO_FAN_SPEED : this.last_fan_speed === AUTO_FAN_SPEED ? 80 : this.last_fan_speed;
-    message.fan_speed = fan_speed;
-    this.attributes.FAN_SPEED = fan_speed;
-    this.attributes.FAN_AUTO = fan_auto;
-    await this.build_send(message);
+    await this.set_attribute({ FAN_AUTO: fan_auto });
   }
 
   set_fan_speed(fan_speed: number, message: MessageGeneralSet | MessageSubProtocolSet) {
@@ -554,49 +581,23 @@ export default class MideaACDevice extends MideaDevice {
   }
 
   async set_swing_angle(swing_direction: SwingAngle, swing_angle: number) {
-    this.logger.info(`[${this.name}] Set swing ${swing_direction} angle to: ${swing_angle}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    this.attributes.SWING_HORIZONTAL = false;
-    this.attributes.SWING_VERTICAL = false;
-    switch (swing_direction) {
-      case SwingAngle.HORIZONTAL:
-        message.wind_swing_lr_angle = swing_angle;
-        this.attributes.WIND_SWING_LR_ANGLE = swing_angle;
-        break;
-      case SwingAngle.VERTICAL:
-        message.wind_swing_ud_angle = swing_angle;
-        this.attributes.WIND_SWING_UD_ANGLE = swing_angle;
-        break;
+    if (swing_direction === SwingAngle.HORIZONTAL) {
+      await this.set_attribute({ WIND_SWING_LR_ANGLE: swing_angle });
+    } else {
+      await this.set_attribute({ WIND_SWING_UD_ANGLE: swing_angle });
     }
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
   }
 
   async set_self_clean(self_clean: boolean) {
-    this.logger.info(`[${this.name}] Set self clean to: ${self_clean}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    message.self_clean = self_clean;
-    this.attributes.SELF_CLEAN = self_clean;
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
+    await this.set_attribute({ SELF_CLEAN: self_clean });
   }
 
   async set_rate_select(rate_select: number) {
-    this.logger.info(`[${this.name}] Set rate select to: ${rate_select}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    message.rate_select = rate_select;
-    this.attributes.RATE_SELECT = rate_select;
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
+    await this.set_attribute({ RATE_SELECT: rate_select });
   }
 
   async set_out_silent(out_silent: boolean) {
-    this.logger.info(`[${this.name}] Set out silent to: ${out_silent}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    message.out_silent = out_silent;
-    this.attributes.OUT_SILENT = out_silent;
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
+    await this.set_attribute({ OUT_SILENT: out_silent });
   }
 
   protected set_subtype(): void {

--- a/src/devices/c3/MideaC3Device.ts
+++ b/src/devices/c3/MideaC3Device.ts
@@ -237,7 +237,7 @@ export default class MideaC3Device extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<C3Attributes>) {
+  protected async apply_attributes(attributes: Partial<C3Attributes>) {
     const messageToSend: {
       SET: MessageSet | undefined;
       SILENT: MessageSetSilent | undefined;
@@ -277,9 +277,9 @@ export default class MideaC3Device extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/cc/MideaCCDevice.ts
+++ b/src/devices/cc/MideaCCDevice.ts
@@ -189,7 +189,7 @@ export default class MideaCCDevice extends MideaDevice {
     return controls;
   }
 
-  async set_attribute(attributes: Partial<CCAttributes>) {
+  protected async apply_attributes(attributes: Partial<CCAttributes>) {
     try {
       const changed: Partial<CCAttributes> = {};
       for (const [k, v] of Object.entries(attributes)) {

--- a/src/devices/cd/MideaCDDevice.ts
+++ b/src/devices/cd/MideaCDDevice.ts
@@ -110,7 +110,7 @@ export default class MideaCDDevice extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<CDAttributes>) {
+  protected async apply_attributes(attributes: Partial<CDAttributes>) {
     const messageToSend: {
       SET: MessageSet | undefined;
     } = {
@@ -134,9 +134,9 @@ export default class MideaCDDevice extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/ce/MideaCEDevice.ts
+++ b/src/devices/ce/MideaCEDevice.ts
@@ -94,7 +94,7 @@ export default class MideaCEDevice extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<CEAttributes>) {
+  protected async apply_attributes(attributes: Partial<CEAttributes>) {
     const messageToSend: {
       SET: MessageSet | undefined;
     } = {
@@ -118,9 +118,9 @@ export default class MideaCEDevice extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/db/MideaDBDevice.ts
+++ b/src/devices/db/MideaDBDevice.ts
@@ -75,7 +75,7 @@ export default class MideaDBDevice extends MideaDevice {
     this.logger.debug('No subtype for FA device');
   }
 
-  async set_attribute(attributes: Partial<DBAttributes>) {
+  protected async apply_attributes(attributes: Partial<DBAttributes>) {
     const messageToSend: {
       POWER: MessagePower | undefined;
       START: MessageStart | undefined;
@@ -109,9 +109,9 @@ export default class MideaDBDevice extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/e1/MideaE1Device.ts
+++ b/src/devices/e1/MideaE1Device.ts
@@ -118,7 +118,7 @@ export default class MideaE1Device extends MideaDevice {
     }
   }
 
-  async set_attribute(attributes: Partial<E1Attributes>) {
+  protected async apply_attributes(attributes: Partial<E1Attributes>) {
     const messageToSend: {
       POWER: MessagePower | undefined;
       CHILD_LOCK: MessageLock | undefined;
@@ -154,9 +154,9 @@ export default class MideaE1Device extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/e2/MideaE2Device.ts
+++ b/src/devices/e2/MideaE2Device.ts
@@ -103,7 +103,7 @@ export default class MideaE2Device extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<E2Attributes>) {
+  protected async apply_attributes(attributes: Partial<E2Attributes>) {
     const messageToSend: {
       POWER: MessagePower | undefined;
       SET: MessageSet | undefined;
@@ -143,9 +143,9 @@ export default class MideaE2Device extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/e3/MideaE3Device.ts
+++ b/src/devices/e3/MideaE3Device.ts
@@ -103,7 +103,7 @@ export default class MideaE3Device extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<E3Attributes>) {
+  protected async apply_attributes(attributes: Partial<E3Attributes>) {
     const messageToSend: {
       POWER: MessagePower | undefined;
       SET: MessageSet | undefined;
@@ -149,9 +149,9 @@ export default class MideaE3Device extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/fa/MideaFADevice.ts
+++ b/src/devices/fa/MideaFADevice.ts
@@ -100,7 +100,7 @@ export default class MideaFADevice extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<FAAttributes>) {
+  protected async apply_attributes(attributes: Partial<FAAttributes>) {
     const messageToSend: {
       SET: MessageSet | undefined;
     } = {
@@ -124,9 +124,9 @@ export default class MideaFADevice extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/devices/fd/MideaFDDevice.ts
+++ b/src/devices/fd/MideaFDDevice.ts
@@ -99,7 +99,7 @@ export default class MideaFDDevice extends MideaDevice {
     return message;
   }
 
-  async set_attribute(attributes: Partial<FDAttributes>) {
+  protected async apply_attributes(attributes: Partial<FDAttributes>) {
     const messageToSend: {
       SET: MessageSet | undefined;
     } = {
@@ -123,9 +123,9 @@ export default class MideaFDDevice extends MideaDevice {
         if (v !== undefined) {
           this.logger.debug(`[${this.name}] Set message ${k}:\n${JSON.stringify(v)}`);
           await this.build_send(v);
-          this.update(attributes);
         }
       }
+      this.update(attributes);
     } catch (err) {
       const msg = err instanceof Error ? err.stack : err;
       this.logger.debug(`[${this.name}] Error in set_attribute (${this.ip}:${this.port}):\n${msg}`);

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -109,7 +109,7 @@ class UiServer extends HomebridgePluginUiServer {
     super();
     const config = (
       JSON.parse(fs.readFileSync(this.homebridgeConfigPath!, 'utf8')) as { platforms: Array<{ platform: string; uiDebug?: boolean }> }
-    ).platforms.find((obj) => obj.platform === 'midea-platform');
+    ).platforms.find((obj) => obj.platform === 'midea-portasplit');
     this.logger = new Logger(config?.uiDebug ?? false);
     this.logger.info('Custom UI created.');
     this.security = new LocalSecurity();

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -107,13 +107,19 @@ class UiServer extends HomebridgePluginUiServer {
 
   constructor() {
     super();
-    const config = (
-      JSON.parse(fs.readFileSync(this.homebridgeConfigPath!, 'utf8')) as { platforms: Array<{ platform: string; uiDebug?: boolean }> }
-    ).platforms.find((obj) => obj.platform === 'midea-portasplit');
-    this.logger = new Logger(config?.uiDebug ?? false);
+    const configPath = this.homebridgeConfigPath!;
+    const fileContent = fs.readFileSync(configPath, 'utf8');
+    const fullConfig = JSON.parse(fileContent);
+    const mideaConfig = fullConfig.platforms.find((obj: { platform: string }) => obj.platform === 'midea-portasplit');
+    
+    console.log('[UI Server] Config path:', configPath);
+    console.log('[UI Server] Found platforms:', fullConfig.platforms.map((p: { platform: string }) => p.platform));
+    console.log('[UI Server] Selected midea-portasplit config:', mideaConfig ? 'FOUND' : 'NOT FOUND');
+
+    this.logger = new Logger(mideaConfig?.uiDebug ?? false);
     this.logger.info('Custom UI created.');
     this.security = new LocalSecurity();
-    this.promiseSocket = new PromiseSocket(this.logger, config?.uiDebug ?? false);
+    this.promiseSocket = new PromiseSocket(this.logger, mideaConfig?.uiDebug ?? false);
 
     this.onRequest(
       '/login',

--- a/src/homebridge-ui/ui.ts
+++ b/src/homebridge-ui/ui.ts
@@ -75,9 +75,14 @@ Alpine.data('discoverApp', () => {
       homebridge.showSpinner();
 
       const pluginConfig = await homebridge.getPluginConfig();
+      console.log('[UI] getPluginConfig returned:', JSON.stringify(pluginConfig, null, 2));
       configSchema = await homebridge.getPluginConfigSchema();
+      console.log('[UI] getPluginConfigSchema returned schema for:', configSchema.pluginAlias);
 
-      if (!pluginConfig.length) pluginConfig.push({});
+      if (!pluginConfig.length) {
+        console.log('[UI] No config found, creating new one.');
+        pluginConfig.push({ platform: configSchema.pluginAlias });
+      }
 
       configuration = pluginConfig[0] as Config;
       defaultsDeep(configuration, defaultConfig);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -143,9 +143,11 @@ export class MideaPlatform implements DynamicPlatformPlugin {
         missingDevices++;
         if (this.discoveredDevices.get(device.id) === undefined) {
           this.discoveredDevices.set(device.id, false);
-          this.log.warn(`[${device.name}] Device not found (id: ${device.id}), will retry every ${this.discoveryInterval} seconds`);
+          this.log.warn(
+            `[${device.name}] Device not found (id: ${device.id}). Check if it's powered on and connected to Wi-Fi. See docs/wifi-setup.md for troubleshooting.`,
+          );
         } else {
-          this.log.debug(`[${device.name}] Device not found (id: ${device.id}), will retry in ${this.discoveryInterval} seconds`);
+          this.log.debug(`[${device.name}] Device not found (id: ${device.id}), retrying discovery...`);
         }
       }
     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -12,6 +12,7 @@ import createAccessory from './accessory/AccessoryFactory.js';
 import { type DeviceInfo, ProtocolVersion } from './core/MideaConstants.js';
 import Discover from './core/MideaDiscover.js';
 import createDevice from './devices/DeviceFactory.js';
+import { WeatherService } from './core/WeatherService.js';
 import { type Config, type DeviceConfig, defaultConfig, defaultDeviceConfig } from './platformUtils.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { defaultsDeep } from 'lodash-es';
@@ -26,6 +27,8 @@ type MideaContext = {
   serviceVersion: number;
   configuredNames: { [key: string]: string };
   thresholds: { [key: string]: number };
+  energy?: number;
+  fallbackSuggested?: boolean;
 };
 
 export type MideaAccessory = PlatformAccessory<MideaContext>;
@@ -36,14 +39,15 @@ export class MideaPlatform implements DynamicPlatformPlugin {
 
   public readonly accessories: Map<string, MideaAccessory> = new Map();
   public readonly discoveredCacheUUIDs: string[] = [];
+  public readonly weatherService: WeatherService;
 
   // Keep track of all devices discovered by broadcast
   private discoveredDevices: Map<number, boolean> = new Map();
   private discoveryInterval = 60; // seconds
 
-  private readonly discover: Discover;
+  public readonly discover: Discover;
   // Need seperate variable because the DynamicPlatformPlugin constructor won't accept anything but the PlatformConfig type
-  private readonly platformConfig: Config;
+  public readonly platformConfig: Config;
 
   constructor(
     public readonly log: Logger,
@@ -63,6 +67,8 @@ export class MideaPlatform implements DynamicPlatformPlugin {
     this.log.debug(`Configuration:\n${JSON.stringify(this.platformConfig, null, 2)}`);
 
     this.discover = new Discover(log);
+
+    this.weatherService = new WeatherService(log, this.platformConfig.weather);
 
     // Register callback with Discover class that is called for each device as
     // they are discovered on the network.
@@ -175,6 +181,7 @@ export class MideaPlatform implements DynamicPlatformPlugin {
     // Add default config values
     defaultsDeep(deviceConfig, defaultDeviceConfig);
     const device = createDevice(this.log, device_info, this.platformConfig, deviceConfig);
+    this.log.debug(`[${device_info.name}] Device config: ${JSON.stringify(deviceConfig, null, 2)}`);
     if (device === null) {
       this.log.error(`Device type is unsupported by the plugin: ${device_info.type}`);
     } else {

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -3,6 +3,14 @@ export type Config = {
   heartbeatInterval: number;
   uiDebug: boolean;
   devices: DeviceConfig[];
+  weather: WeatherConfig;
+};
+
+export type WeatherConfig = {
+  enabled: boolean;
+  apiKey: string;
+  location?: string;
+  interval: number;
 };
 
 export const defaultConfig: Config = {
@@ -10,6 +18,11 @@ export const defaultConfig: Config = {
   heartbeatInterval: 10,
   uiDebug: false,
   devices: [],
+  weather: {
+    enabled: false,
+    apiKey: '',
+    interval: 30,
+  },
 };
 
 export type DeviceConfig = {
@@ -77,36 +90,70 @@ type ACOptions = {
   swing: {
     mode: SwingMode;
     angleAccessory: boolean;
+    angleAccessoryName?: string;
     angleMainControl: SwingAngle;
   };
   heatingCapable: boolean;
   ecoSwitch: boolean;
-  displaySwitch: {
-    flag: boolean;
-    command: boolean;
-  };
+  ecoSwitchName?: string;
+  displaySwitch: boolean;
+  displaySwitchAlternate: boolean;
+  displaySwitchName?: string;
   minTemp: number;
   maxTemp: number;
   tempStep: number;
   fahrenheit: boolean;
   fanOnlyModeSwitch: boolean;
+  fanOnlyModeSwitchName?: string;
   fanAccessory: boolean;
+  fanAccessoryName?: string;
   fanAutoSwitch: boolean;
+  fanAutoSwitchName?: string;
+  coolModeSwitch: boolean;
+  coolModeSwitchName?: string;
+  heatModeSwitch: boolean;
+  heatModeSwitchName?: string;
+  autoModeSwitch: boolean;
+  autoModeSwitchName?: string;
   breezeAwaySwitch: boolean;
+  breezeAwaySwitchName?: string;
   dryModeSwitch: boolean;
+  dryModeSwitchName?: string;
   boostModeSwitch: boolean;
+  boostModeSwitchName?: string;
   auxHeatingSwitches: boolean;
+  auxHeatingSwitchesName?: string;
+  auxHeatingSwitchesPlusHeatName?: string;
   selfCleanSwitch: boolean;
+  selfCleanSwitchName?: string;
   ionSwitch: boolean;
+  ionSwitchName?: string;
   outSilentSwitch: boolean;
+  outSilentSwitchName?: string;
   rateSelector: boolean;
+  rateSelectorName?: string;
   outDoorTemp: boolean;
-  audioFeedback: boolean;
-  screenOff: boolean;
+  outDoorTempName?: string;
+  audioFeedbackSwitch: boolean;
+  audioFeedbackSwitchName?: string;
+  smartEyeSwitch: boolean;
+  smartEyeSwitchName?: string;
+  powerMeter: boolean;
+  powerMeterName?: string;
+  timerSwitch: boolean;
+  timerSwitchName?: string;
   sleepModeSwitch: boolean;
+  sleepModeSwitchName?: string;
   comfortModeSwitch: boolean;
+  comfortModeSwitchName?: string;
   temperatureSensor: boolean;
+  temperatureSensorName?: string;
   humiditySensor: boolean;
+  humiditySensorName?: string;
+  humidityWeatherFallback: boolean;
+  powerDisplayType: 'None' | 'Lux' | 'Humidity' | 'CarbonDioxide' | 'Temperature';
+  energyDisplayType: 'None' | 'Lux' | 'Humidity' | 'CarbonDioxide' | 'Temperature';
+  fanSpeedMode: 'None' | '3' | '5';
 };
 
 type A1Options = {
@@ -119,6 +166,7 @@ type A1Options = {
   maxHumidity: number;
   humidityStep: number;
   humidityOffset: number;
+  humidityWeatherFallback: boolean;
 };
 
 type C3Options = {
@@ -211,19 +259,19 @@ export const defaultDeviceConfig: DeviceConfig = {
     },
     heatingCapable: true,
     outDoorTemp: false,
-    audioFeedback: false,
-    screenOff: false,
+    audioFeedbackSwitch: false,
+    smartEyeSwitch: false,
+    powerMeter: false,
     ecoSwitch: false,
+    displaySwitch: false,
+    displaySwitchAlternate: false,
     dryModeSwitch: false,
     boostModeSwitch: false,
     breezeAwaySwitch: false,
-    displaySwitch: {
-      flag: true,
-      command: false,
-    },
     auxHeatingSwitches: false,
     selfCleanSwitch: false,
     ionSwitch: false,
+    timerSwitch: false,
     outSilentSwitch: false,
     rateSelector: false,
     minTemp: 16,
@@ -233,10 +281,17 @@ export const defaultDeviceConfig: DeviceConfig = {
     fanOnlyModeSwitch: false,
     fanAccessory: false,
     fanAutoSwitch: false,
+    coolModeSwitch: false,
+    heatModeSwitch: false,
+    autoModeSwitch: false,
     sleepModeSwitch: false,
     comfortModeSwitch: false,
     temperatureSensor: false,
     humiditySensor: false,
+    humidityWeatherFallback: false,
+    powerDisplayType: 'Lux',
+    energyDisplayType: 'None',
+    fanSpeedMode: 'None',
   },
   A1_options: {
     temperatureSensor: false,
@@ -248,6 +303,7 @@ export const defaultDeviceConfig: DeviceConfig = {
     maxHumidity: 85,
     humidityStep: 5,
     humidityOffset: 0,
+    humidityWeatherFallback: false,
   },
   C3_options: {
     zone1: false,

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -37,6 +37,7 @@ export type DeviceConfig = {
     logRecoverableErrors: boolean;
     logRefreshStatusErrors: boolean;
     registerIfOffline: boolean;
+    refreshBeforeSet: boolean;
     sub_type?: number;
   };
   AC_options: ACOptions;
@@ -249,6 +250,7 @@ export const defaultDeviceConfig: DeviceConfig = {
     logRecoverableErrors: true,
     logRefreshStatusErrors: true,
     registerIfOffline: false,
+    refreshBeforeSet: false,
   },
   AC_options: {
     serviceType: ACServiceType.HEATER_COOLER,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 /**
  * This is the name of the platform that users will use to register the plugin in the Homebridge config.json
  */
-export const PLATFORM_NAME = 'midea-platform';
+export const PLATFORM_NAME = 'midea-portasplit';
 
 /**
  * This must match the name of your plugin as defined the package.json

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,4 +6,4 @@ export const PLATFORM_NAME = 'midea-platform';
 /**
  * This must match the name of your plugin as defined the package.json
  */
-export const PLUGIN_NAME = 'homebridge-midea-platform';
+export const PLUGIN_NAME = '@jouskaio/homebridge-midea-portasplit';


### PR DESCRIPTION
## What does this PR do?

This Pull Request introduces several major features and stability improvements to enhance the user experience, particularly regarding energy monitoring, sensor reliability, and multi-platform compatibility (Matter). These changes were initially developed to improve compatibility and feature parity for the **Midea Portasplit**, but benefit all supported Midea AC and Dehumidifier units.

Key Features:

- **Eve History Integration**: Added `fakegato-history` support for Air Conditioners and Dehumidifiers. Users can now view historical graphs for temperature, humidity, power (W), and energy (kWh) directly in the Eve Home app.
- **Weather-based Humidity Fallback**: Implemented a `WeatherService` using OpenWeatherMap API. This provides a reliable fallback for indoor humidity when a device's physical sensor is defective (reporting 0% or 255%).
- **Enhanced Power/Energy Monitoring**:
  - Added configurable display types for power consumption (Lux, CO2 ppm, or Temperature) to work around Apple Home app limitations.
  - Fixed CO2 sensor implementation by adding mandatory characteristics.
  - Ensured energy consumption data is monotonically increasing for better data integrity.
- **Improved Fan Logic**: Resolved a bug where manual fan speed settings were overridden by "Auto" mode. Improved transitions between manual and automatic fan control.
- **Stability & Deployment**: Updated deployment scripts and `package.json` to handle missing dependencies on remote environments and improved service lifecycle management to prevent duplicate accessories.

## How was it tested?

- **Device**: Midea Portasplit (Model `0A804601`).
- **Environment**: Homebridge v2.3.1 running on Node.js v24.19.0.
- **Tests**:
  - Verified `fakegato-history` data injection and graph rendering in the Eve Home app.
  - Validated `WeatherService` event-driven updates and fallback triggers.
  - Confirmed fix for fan speed oscillation by monitoring network commands and device responses.
  - Verified successful build using `npm run build`.

## AI assistance disclosure

Assisted-by: Junie (JetBrains AI)

---

**Checklist**

- [x] I read the [contribution guidelines](/CONTRIBUTING.md)
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](/CONTRIBUTING.md#ai-policy)
- [x] I tested this on real hardware (Midea Portasplit)
- [x] I ran `npm run lint` and `npm run fmt:check` and there are no warnings
