### PR TITLE
fix(ac): avoid waking display during status refresh

### DIFF
--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -12,11 +12,7 @@ import MideaDevice, { type DeviceAttributeBase } from '../../core/MideaDevice.js
 import { ACMode, type Config, type DeviceConfig, SwingAngle } from '../../platformUtils.js';
 import {
   MessageACResponse,
-  MessageCapabilitiesAdditionalQuery,
-  MessageCapabilitiesQuery,
   MessageGeneralSet,
-  MessageGroupZeroQuery,
-  MessageHumidityQuery,
   MessageNewProtocolQuery,
   MessageNewProtocolSet,
   MessagePowerQuery,
@@ -104,7 +100,6 @@ export default class MideaACDevice extends MideaDevice {
 
   private fresh_air_version?: number;
   private used_subprotocol = false;
-  private capabilities_queried = false;
   private bb_sn8_flag = false;
   private bb_timer = false;
   private readonly DEFAULT_POWER_ANALYSIS_METHOD = 2;
@@ -180,20 +175,12 @@ export default class MideaACDevice extends MideaDevice {
         new MessageSubProtocolQuery(this.device_protocol_version, 0x30),
       ];
     }
-    const queries = [
+    return [
       new MessageQuery(this.device_protocol_version),
       // Querying display status wakes the screen on some Q-series units.
       new MessageNewProtocolQuery(this.device_protocol_version, this.alternate_switch_display),
       new MessagePowerQuery(this.device_protocol_version),
-      new MessageHumidityQuery(this.device_protocol_version),
-      new MessageGroupZeroQuery(this.device_protocol_version),
     ];
-    if (!this.capabilities_queried) {
-      queries.push(new MessageCapabilitiesQuery(this.device_protocol_version));
-      queries.push(new MessageCapabilitiesAdditionalQuery(this.device_protocol_version));
-      this.capabilities_queried = true;
-    }
-    return queries;
   }
 
   process_message(msg: Buffer) {

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -182,7 +182,8 @@ export default class MideaACDevice extends MideaDevice {
     }
     const queries = [
       new MessageQuery(this.device_protocol_version),
-      new MessageNewProtocolQuery(this.device_protocol_version),
+      // Querying display status wakes the screen on some Q-series units.
+      new MessageNewProtocolQuery(this.device_protocol_version, this.alternate_switch_display),
       new MessagePowerQuery(this.device_protocol_version),
       new MessageHumidityQuery(this.device_protocol_version),
       new MessageGroupZeroQuery(this.device_protocol_version),

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -12,7 +12,11 @@ import MideaDevice, { type DeviceAttributeBase } from '../../core/MideaDevice.js
 import { ACMode, type Config, type DeviceConfig, SwingAngle } from '../../platformUtils.js';
 import {
   MessageACResponse,
+  MessageCapabilitiesAdditionalQuery,
+  MessageCapabilitiesQuery,
   MessageGeneralSet,
+  MessageGroupZeroQuery,
+  MessageHumidityQuery,
   MessageNewProtocolQuery,
   MessageNewProtocolSet,
   MessagePowerQuery,
@@ -100,6 +104,7 @@ export default class MideaACDevice extends MideaDevice {
 
   private fresh_air_version?: number;
   private used_subprotocol = false;
+  private capabilities_queried = false;
   private bb_sn8_flag = false;
   private bb_timer = false;
   private readonly DEFAULT_POWER_ANALYSIS_METHOD = 2;
@@ -175,12 +180,19 @@ export default class MideaACDevice extends MideaDevice {
         new MessageSubProtocolQuery(this.device_protocol_version, 0x30),
       ];
     }
-    return [
+    const queries = [
       new MessageQuery(this.device_protocol_version),
-      // Querying display status wakes the screen on some Q-series units.
       new MessageNewProtocolQuery(this.device_protocol_version, this.alternate_switch_display),
       new MessagePowerQuery(this.device_protocol_version),
+      new MessageHumidityQuery(this.device_protocol_version),
+      new MessageGroupZeroQuery(this.device_protocol_version),
     ];
+    if (!this.capabilities_queried) {
+      queries.push(new MessageCapabilitiesQuery(this.device_protocol_version));
+      queries.push(new MessageCapabilitiesAdditionalQuery(this.device_protocol_version));
+      this.capabilities_queried = true;
+    }
+    return queries;
   }
 
   process_message(msg: Buffer) {

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -111,6 +111,7 @@ export default class MideaACDevice extends MideaDevice {
   private power_analysis_method?: number;
 
   private alternate_switch_display = false;
+  private supports_rate_select = false;
   private last_fan_speed = AUTO_FAN_SPEED; // default to Auto
 
   private defaultFahrenheit: boolean;
@@ -182,7 +183,7 @@ export default class MideaACDevice extends MideaDevice {
     }
     const queries = [
       new MessageQuery(this.device_protocol_version),
-      new MessageNewProtocolQuery(this.device_protocol_version, this.alternate_switch_display),
+      new MessageNewProtocolQuery(this.device_protocol_version, this.alternate_switch_display, this.supports_rate_select),
       new MessagePowerQuery(this.device_protocol_version),
       new MessageHumidityQuery(this.device_protocol_version),
       new MessageGroupZeroQuery(this.device_protocol_version),
@@ -201,6 +202,11 @@ export default class MideaACDevice extends MideaDevice {
       this.logger.debug(`[${this.name}] Body:\n${JSON.stringify(message.body)}`);
     }
     const changed: DeviceAttributeBase = {};
+    const b5Electricity = message.get_body_attribute('b5_electricity');
+    if (b5Electricity !== undefined) {
+      // A nonzero B5 electricity value is the number of supported rate-select levels.
+      this.supports_rate_select = b5Electricity > 0;
+    }
     let has_fresh_air = false;
     if (message.used_subprotocol) {
       this.used_subprotocol = true;

--- a/src/devices/ac/MideaACMessage.ts
+++ b/src/devices/ac/MideaACMessage.ts
@@ -262,7 +262,7 @@ export class MessageNewProtocolQuery extends MessageACBase {
       NewProtocolTags.RATE_SELECT,
       NewProtocolTags.OUT_SILENT,
       NewProtocolTags.BUZZER_ALL,
-      NewProtocolTags.ERROR_CODE_QUERY,
+      // Do not add ERROR_CODE_QUERY: some Q-series units treat it as a display action and briefly show "EC".
     ];
     let body = Buffer.from([query_params.length]);
     for (const param of query_params) {

--- a/src/devices/ac/MideaACMessage.ts
+++ b/src/devices/ac/MideaACMessage.ts
@@ -241,7 +241,10 @@ export class MessageSwitchDisplay extends MessageACBase {
 }
 
 export class MessageNewProtocolQuery extends MessageACBase {
-  constructor(device_protocol_version: number) {
+  constructor(
+    device_protocol_version: number,
+    private readonly query_screen_display = false,
+  ) {
     super(device_protocol_version, MessageType.QUERY, 0xb1);
   }
 
@@ -252,7 +255,7 @@ export class MessageNewProtocolQuery extends MessageACBase {
       NewProtocolTags.INDIRECT_WIND,
       NewProtocolTags.BREEZELESS,
       NewProtocolTags.INDOOR_HUMIDITY,
-      NewProtocolTags.SCREEN_DISPLAY,
+      ...(this.query_screen_display ? [NewProtocolTags.SCREEN_DISPLAY] : []),
       NewProtocolTags.FRESH_AIR_1,
       NewProtocolTags.FRESH_AIR_2,
       NewProtocolTags.SELF_CLEAN,

--- a/src/devices/ac/MideaACMessage.ts
+++ b/src/devices/ac/MideaACMessage.ts
@@ -31,6 +31,7 @@ enum NewProtocolTags {
   B5_STRONG_WIND = 0x021a,
   B5_HUMIDITY = 0x021f,
   B5_TEMPERATURE = 0x0225,
+  B5_ELECTRICITY = 0x0216,
   B5_FILTER_REMIND = 0x0217,
   B5_SCREEN_DISPLAY = 0x0224,
   B5_ANION = 0x021e,
@@ -244,6 +245,7 @@ export class MessageNewProtocolQuery extends MessageACBase {
   constructor(
     device_protocol_version: number,
     private readonly query_screen_display = false,
+    private readonly query_rate_select = false,
   ) {
     super(device_protocol_version, MessageType.QUERY, 0xb1);
   }
@@ -259,7 +261,7 @@ export class MessageNewProtocolQuery extends MessageACBase {
       NewProtocolTags.FRESH_AIR_1,
       NewProtocolTags.FRESH_AIR_2,
       NewProtocolTags.SELF_CLEAN,
-      NewProtocolTags.RATE_SELECT,
+      ...(this.query_rate_select ? [NewProtocolTags.RATE_SELECT] : []),
       NewProtocolTags.OUT_SILENT,
       NewProtocolTags.BUZZER_ALL,
       // Do not add ERROR_CODE_QUERY: some Q-series units treat it as a display action and briefly show "EC".
@@ -823,6 +825,7 @@ class XB5MessageBody extends NewProtocolMessageBody {
   public b5_temperature4?: number;
   public b5_temperature5?: number;
   public b5_temperature6?: number;
+  public b5_electricity?: number;
   public b5_screen_display?: number;
   public b5_sound?: number;
   public b5_humidity?: number;
@@ -859,6 +862,10 @@ class XB5MessageBody extends NewProtocolMessageBody {
       this.b5_temperature4 = params[NewProtocolTags.B5_TEMPERATURE][4];
       this.b5_temperature5 = params[NewProtocolTags.B5_TEMPERATURE][5];
       this.b5_temperature6 = params[NewProtocolTags.B5_TEMPERATURE][6];
+    }
+
+    if (NewProtocolTags.B5_ELECTRICITY in params) {
+      this.b5_electricity = params[NewProtocolTags.B5_ELECTRICITY][0];
     }
 
     if (NewProtocolTags.B5_SCREEN_DISPLAY in params) {

--- a/test/ac-query.test.js
+++ b/test/ac-query.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DeviceType, ProtocolVersion } from '../src/core/MideaConstants.ts';
+import MideaACDevice from '../src/devices/ac/MideaACDevice.ts';
+import { MessageNewProtocolQuery } from '../src/devices/ac/MideaACMessage.ts';
+import { defaultConfig, defaultDeviceConfig } from '../src/platformUtils.ts';
+
+const SCREEN_DISPLAY_TAG = 0x0017;
+
+const logger = {
+  debug() {},
+  error() {},
+  info() {},
+  warn() {},
+};
+
+function createDevice() {
+  return new MideaACDevice(
+    logger,
+    {
+      ip: '127.0.0.1',
+      port: 6444,
+      id: 1,
+      model: 'test',
+      sn: 'test',
+      name: 'Test AC',
+      type: DeviceType.AIR_CONDITIONER,
+      version: ProtocolVersion.V3,
+    },
+    structuredClone(defaultConfig),
+    structuredClone(defaultDeviceConfig),
+  );
+}
+
+function getNewProtocolQueryTags(device) {
+  const query = device.build_query().find((message) => message instanceof MessageNewProtocolQuery);
+  assert.ok(query);
+
+  const body = query._body;
+  const count = body[0];
+  assert.equal(body.length, 1 + count * 2);
+
+  return Array.from({ length: count }, (_, index) => body.readUInt16LE(1 + index * 2));
+}
+
+test('only queries display status when the alternate display command is enabled', () => {
+  const device = createDevice();
+  assert.equal(getNewProtocolQueryTags(device).includes(SCREEN_DISPLAY_TAG), false);
+
+  device.set_alternate_switch_display(true);
+  assert.equal(getNewProtocolQueryTags(device).includes(SCREEN_DISPLAY_TAG), true);
+});

--- a/test/ac-query.test.js
+++ b/test/ac-query.test.js
@@ -2,10 +2,19 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DeviceType, ProtocolVersion } from '../src/core/MideaConstants.ts';
 import MideaACDevice from '../src/devices/ac/MideaACDevice.ts';
-import { MessageNewProtocolQuery, MessagePowerQuery, MessageQuery } from '../src/devices/ac/MideaACMessage.ts';
+import {
+  MessageCapabilitiesAdditionalQuery,
+  MessageCapabilitiesQuery,
+  MessageGroupZeroQuery,
+  MessageHumidityQuery,
+  MessageNewProtocolQuery,
+  MessagePowerQuery,
+  MessageQuery,
+} from '../src/devices/ac/MideaACMessage.ts';
 import { defaultConfig, defaultDeviceConfig } from '../src/platformUtils.ts';
 
 const SCREEN_DISPLAY_TAG = 0x0017;
+const ERROR_CODE_QUERY_TAG = 0x003f;
 
 const logger = {
   debug() {},
@@ -43,19 +52,30 @@ function getNewProtocolQueryTags(device) {
   return Array.from({ length: count }, (_, index) => body.readUInt16LE(1 + index * 2));
 }
 
-test('uses the pre-v1.3 periodic query set', () => {
-  const queries = createDevice().build_query();
+test('preserves periodic queries and only requests capabilities once', () => {
+  const device = createDevice();
+  const queries = device.build_query();
 
-  assert.equal(queries.length, 3);
+  assert.equal(queries.length, 7);
   assert.ok(queries[0] instanceof MessageQuery);
   assert.ok(queries[1] instanceof MessageNewProtocolQuery);
   assert.ok(queries[2] instanceof MessagePowerQuery);
+  assert.ok(queries[3] instanceof MessageHumidityQuery);
+  assert.ok(queries[4] instanceof MessageGroupZeroQuery);
+  assert.ok(queries[5] instanceof MessageCapabilitiesQuery);
+  assert.ok(queries[6] instanceof MessageCapabilitiesAdditionalQuery);
+
+  assert.equal(device.build_query().length, 5);
 });
 
-test('only queries display status when the alternate display command is enabled', () => {
+test('omits display-waking tags from the periodic extended query', () => {
   const device = createDevice();
-  assert.equal(getNewProtocolQueryTags(device).includes(SCREEN_DISPLAY_TAG), false);
+  const tags = getNewProtocolQueryTags(device);
+  assert.equal(tags.includes(SCREEN_DISPLAY_TAG), false);
+  assert.equal(tags.includes(ERROR_CODE_QUERY_TAG), false);
 
   device.set_alternate_switch_display(true);
-  assert.equal(getNewProtocolQueryTags(device).includes(SCREEN_DISPLAY_TAG), true);
+  const alternateDisplayTags = getNewProtocolQueryTags(device);
+  assert.equal(alternateDisplayTags.includes(SCREEN_DISPLAY_TAG), true);
+  assert.equal(alternateDisplayTags.includes(ERROR_CODE_QUERY_TAG), false);
 });

--- a/test/ac-query.test.js
+++ b/test/ac-query.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DeviceType, ProtocolVersion } from '../src/core/MideaConstants.ts';
 import MideaACDevice from '../src/devices/ac/MideaACDevice.ts';
-import { MessageNewProtocolQuery } from '../src/devices/ac/MideaACMessage.ts';
+import { MessageNewProtocolQuery, MessagePowerQuery, MessageQuery } from '../src/devices/ac/MideaACMessage.ts';
 import { defaultConfig, defaultDeviceConfig } from '../src/platformUtils.ts';
 
 const SCREEN_DISPLAY_TAG = 0x0017;
@@ -42,6 +42,15 @@ function getNewProtocolQueryTags(device) {
 
   return Array.from({ length: count }, (_, index) => body.readUInt16LE(1 + index * 2));
 }
+
+test('uses the pre-v1.3 periodic query set', () => {
+  const queries = createDevice().build_query();
+
+  assert.equal(queries.length, 3);
+  assert.ok(queries[0] instanceof MessageQuery);
+  assert.ok(queries[1] instanceof MessageNewProtocolQuery);
+  assert.ok(queries[2] instanceof MessagePowerQuery);
+});
 
 test('only queries display status when the alternate display command is enabled', () => {
   const device = createDevice();

--- a/test/ac-query.test.js
+++ b/test/ac-query.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DeviceType, ProtocolVersion } from '../src/core/MideaConstants.ts';
+import { MessageType } from '../src/core/MideaMessage.ts';
 import MideaACDevice from '../src/devices/ac/MideaACDevice.ts';
 import {
   MessageCapabilitiesAdditionalQuery,
@@ -15,6 +16,7 @@ import { defaultConfig, defaultDeviceConfig } from '../src/platformUtils.ts';
 
 const SCREEN_DISPLAY_TAG = 0x0017;
 const ERROR_CODE_QUERY_TAG = 0x003f;
+const RATE_SELECT_TAG = 0x0048;
 
 const logger = {
   debug() {},
@@ -52,6 +54,10 @@ function getNewProtocolQueryTags(device) {
   return Array.from({ length: count }, (_, index) => body.readUInt16LE(1 + index * 2));
 }
 
+function createB5ElectricityResponse(value) {
+  return Buffer.from([0xaa, 16, DeviceType.AIR_CONDITIONER, 0, 0, 0, 0, 0, ProtocolVersion.V3, MessageType.QUERY, 0xb5, 0x01, 0x16, 0x02, 0x01, value, 0]);
+}
+
 test('preserves periodic queries and only requests capabilities once', () => {
   const device = createDevice();
   const queries = device.build_query();
@@ -68,14 +74,26 @@ test('preserves periodic queries and only requests capabilities once', () => {
   assert.equal(device.build_query().length, 5);
 });
 
-test('omits display-waking tags from the periodic extended query', () => {
+test('omits unsupported tags from the periodic extended query', () => {
   const device = createDevice();
   const tags = getNewProtocolQueryTags(device);
   assert.equal(tags.includes(SCREEN_DISPLAY_TAG), false);
   assert.equal(tags.includes(ERROR_CODE_QUERY_TAG), false);
+  assert.equal(tags.includes(RATE_SELECT_TAG), false);
 
   device.set_alternate_switch_display(true);
   const alternateDisplayTags = getNewProtocolQueryTags(device);
   assert.equal(alternateDisplayTags.includes(SCREEN_DISPLAY_TAG), true);
   assert.equal(alternateDisplayTags.includes(ERROR_CODE_QUERY_TAG), false);
+  assert.equal(alternateDisplayTags.includes(RATE_SELECT_TAG), false);
+});
+
+test('only queries rate select after B5 electricity advertises it', () => {
+  const device = createDevice();
+
+  device.process_message(createB5ElectricityResponse(0));
+  assert.equal(getNewProtocolQueryTags(device).includes(RATE_SELECT_TAG), false);
+
+  device.process_message(createB5ElectricityResponse(4));
+  assert.equal(getNewProtocolQueryTags(device).includes(RATE_SELECT_TAG), true);
 });


### PR DESCRIPTION
## What does this PR do?

Avoids querying optional extended-status tags until the device reports that it supports them. This keeps normal status refreshes from sending display-related query traffic that can wake a disabled front-panel display.

## How was it tested?

- Added regression coverage for the default query, the alternate display path, and supported and unsupported capability replies.
- `npm test`
- `npm run lint`
- `npm run fmt:check`
- `npm run build`
- Verified the scoped behavior on local V3 AC hardware with the display disabled.

The PR remains draft pending a longer normal-polling observation.

## AI assistance disclosure

Assisted by OpenAI Codex. The change, tests, and rationale were reviewed by the contributor.

---

**Checklist**

- [x] I read the [contribution guidelines](/CONTRIBUTING.md)
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](/CONTRIBUTING.md#ai-policy)
- [x] I tested this on real hardware (required for device-specific changes)
- [x] I ran npm run lint and npm run fmt:check and there are no warnings
