### PR TITLE
fix: coalesce ac attribute writes

### DIFF
--- a/src/accessory/AirConditionerAccessory.ts
+++ b/src/accessory/AirConditionerAccessory.ts
@@ -661,16 +661,16 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     if (this.useThermostat) {
       switch (value) {
         case this.platform.Characteristic.TargetHeatingCoolingState.OFF:
-          await this.device.set_attribute({ POWER: false });
+          await this.device.queue_attribute({ POWER: false });
           break;
         case this.platform.Characteristic.TargetHeatingCoolingState.COOL:
-          await this.device.set_attribute({ POWER: true, MODE: ACMode.COOLING });
+          await this.device.queue_attribute({ POWER: true, MODE: ACMode.COOLING });
           break;
         case this.platform.Characteristic.TargetHeatingCoolingState.HEAT:
-          await this.device.set_attribute({ POWER: true, MODE: ACMode.HEATING });
+          await this.device.queue_attribute({ POWER: true, MODE: ACMode.HEATING });
           break;
         case this.platform.Characteristic.TargetHeatingCoolingState.AUTO:
-          await this.device.set_attribute({ POWER: true, MODE: ACMode.AUTO });
+          await this.device.queue_attribute({ POWER: true, MODE: ACMode.AUTO });
           break;
       }
       return;
@@ -678,13 +678,13 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
     switch (value) {
       case this.platform.Characteristic.TargetHeaterCoolerState.AUTO:
-        await this.device.set_attribute({ POWER: true, MODE: ACMode.AUTO });
+        await this.device.queue_attribute({ POWER: true, MODE: ACMode.AUTO });
         break;
       case this.platform.Characteristic.TargetHeaterCoolerState.COOL:
-        await this.device.set_attribute({ POWER: true, MODE: ACMode.COOLING });
+        await this.device.queue_attribute({ POWER: true, MODE: ACMode.COOLING });
         break;
       case this.platform.Characteristic.TargetHeaterCoolerState.HEAT:
-        await this.device.set_attribute({ POWER: true, MODE: ACMode.HEATING });
+        await this.device.queue_attribute({ POWER: true, MODE: ACMode.HEATING });
         break;
     }
 
@@ -699,7 +699,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setActive(value: CharacteristicValue) {
-    await this.device.set_attribute({ POWER: !!value });
+    await this.device.queue_attribute({ POWER: !!value });
     this.device.attributes.SCREEN_DISPLAY = !!value;
     this.displayService?.updateCharacteristic(this.platform.Characteristic.On, !!value);
   }
@@ -711,7 +711,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setTemperatureDisplayUnits(value: CharacteristicValue) {
-    await this.device.set_attribute({
+    await this.device.queue_attribute({
       TEMP_FAHRENHEIT: value === this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT,
     });
   }
@@ -730,7 +730,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
     const target = limitValue(Math.round(+value / tempStep) * tempStep, minTemp, maxTemp);
 
     if (this.getTargetTemperature() === target) return;
-    await this.device.set_target_temperature(target);
+    await this.device.queue_attribute({ TARGET_TEMPERATURE: target });
   }
 
   async setTargetTemperatureWithinThresholds() {
@@ -778,9 +778,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setFanOnlyMode(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ POWER: true, MODE: ACMode.FAN_ONLY });
+      await this.device.queue_attribute({ POWER: true, MODE: ACMode.FAN_ONLY });
     } else {
-      await this.device.set_attribute({ POWER: false, MODE: ACMode.OFF });
+      await this.device.queue_attribute({ POWER: false, MODE: ACMode.OFF });
     }
   }
 
@@ -789,11 +789,11 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setFanState(value: CharacteristicValue) {
-    await this.device.set_fan_auto(value === this.platform.Characteristic.TargetFanState.AUTO);
+    await this.device.queue_attribute({ FAN_AUTO: value === this.platform.Characteristic.TargetFanState.AUTO });
   }
 
   async setFanAuto(value: CharacteristicValue) {
-    await this.device.set_fan_auto(value === true);
+    await this.device.queue_attribute({ FAN_AUTO: value === true });
   }
 
   setHeatingCoolingTemperatureThresholds(thresholds: { heating?: number; cooling?: number }) {
@@ -834,17 +834,11 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setSwingMode(value: CharacteristicValue) {
-    switch (value) {
-      case this.platform.Characteristic.SwingMode.SWING_ENABLED:
-        await this.device.set_swing(
-          [SwingMode.HORIZONTAL, SwingMode.BOTH].includes(this.configDev.AC_options.swing.mode),
-          [SwingMode.VERTICAL, SwingMode.BOTH].includes(this.configDev.AC_options.swing.mode),
-        );
-        break;
-      case this.platform.Characteristic.SwingMode.SWING_DISABLED:
-        await this.device.set_swing(false, false);
-        break;
-    }
+    const enabled = value === this.platform.Characteristic.SwingMode.SWING_ENABLED;
+    await this.device.queue_attribute({
+      SWING_HORIZONTAL: enabled && [SwingMode.HORIZONTAL, SwingMode.BOTH].includes(this.configDev.AC_options.swing.mode),
+      SWING_VERTICAL: enabled && [SwingMode.VERTICAL, SwingMode.BOTH].includes(this.configDev.AC_options.swing.mode),
+    });
   }
 
   getRotationSpeed(): CharacteristicValue {
@@ -852,7 +846,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setRotationSpeed(value: CharacteristicValue) {
-    await this.device.set_attribute({ FAN_SPEED: value as number });
+    await this.device.queue_attribute({ FAN_SPEED: value as number });
   }
 
   getIndoorHumidity(): CharacteristicValue {
@@ -869,7 +863,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setDisplayActive(value: CharacteristicValue) {
     if (this.device.attributes.POWER) {
-      await this.device.set_attribute({ SCREEN_DISPLAY: !!value });
+      await this.device.queue_attribute({ SCREEN_DISPLAY: !!value });
     }
   }
 
@@ -878,7 +872,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setEcoMode(value: CharacteristicValue) {
-    await this.device.set_attribute({ ECO_MODE: !!value });
+    await this.device.queue_attribute({ ECO_MODE: !!value });
   }
 
   getBreezeAway(): CharacteristicValue {
@@ -886,7 +880,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setBreezeAway(value: CharacteristicValue) {
-    await this.device.set_attribute({ INDIRECT_WIND: !!value });
+    await this.device.queue_attribute({ INDIRECT_WIND: !!value });
   }
 
   getDryMode(): CharacteristicValue {
@@ -895,9 +889,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setDryMode(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ POWER: true, MODE: ACMode.DRY });
+      await this.device.queue_attribute({ POWER: true, MODE: ACMode.DRY });
     } else {
-      await this.device.set_attribute({ POWER: false });
+      await this.device.queue_attribute({ POWER: false });
     }
   }
 
@@ -907,9 +901,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setBoostMode(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ POWER: true, BOOST_MODE: true });
+      await this.device.queue_attribute({ POWER: true, BOOST_MODE: true });
     } else {
-      await this.device.set_attribute({ BOOST_MODE: false });
+      await this.device.queue_attribute({ BOOST_MODE: false });
     }
   }
 
@@ -919,9 +913,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setAux(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ SMART_EYE: true });
+      await this.device.queue_attribute({ SMART_EYE: true });
     } else {
-      await this.device.set_attribute({ SMART_EYE: false });
+      await this.device.queue_attribute({ SMART_EYE: false });
     }
   }
 
@@ -931,9 +925,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setAuxHeating(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ AUX_HEATING: true });
+      await this.device.queue_attribute({ AUX_HEATING: true });
     } else {
-      await this.device.set_attribute({ AUX_HEATING: false });
+      await this.device.queue_attribute({ AUX_HEATING: false });
     }
   }
 
@@ -942,7 +936,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setSelfCleanState(value: CharacteristicValue) {
-    await this.device.set_self_clean(value === true);
+    await this.device.queue_attribute({ SELF_CLEAN: value === true });
   }
 
   getIonState(): CharacteristicValue {
@@ -950,7 +944,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setIonState(value: CharacteristicValue) {
-    await this.device.set_attribute({ ANION: !!value });
+    await this.device.queue_attribute({ ANION: !!value });
   }
 
   getOutSilent(): CharacteristicValue {
@@ -958,7 +952,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setOutSilent(value: CharacteristicValue) {
-    await this.device.set_out_silent(!!value);
+    await this.device.queue_attribute({ OUT_SILENT: !!value });
   }
 
   getRateSelect(): CharacteristicValue {
@@ -966,7 +960,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setRateSelect(value: CharacteristicValue) {
-    await this.device.set_rate_select(value as number);
+    await this.device.queue_attribute({ RATE_SELECT: value as number });
   }
 
   getSwingAngleCurrentPosition(): CharacteristicValue {
@@ -980,7 +974,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setSwingAngleTargetPosition(value: CharacteristicValue) {
-    await this.device.set_swing_angle(this.swingAngleMainControl, Math.max(1, value as number));
+    const swing_angle = Math.max(1, value as number);
+    const swing_direction = this.swingAngleMainControl === SwingAngle.VERTICAL ? 'WIND_SWING_UD_ANGLE' : 'WIND_SWING_LR_ANGLE';
+    await this.device.queue_attribute({ [swing_direction]: swing_angle });
   }
 
   getSwingAnglePositionState(): CharacteristicValue {
@@ -996,7 +992,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setSwingAngleTargetHorizontalTiltAngle(value: CharacteristicValue) {
-    await this.device.set_swing_angle(SwingAngle.HORIZONTAL, Math.max(1, value as number));
+    await this.device.queue_attribute({ WIND_SWING_LR_ANGLE: Math.max(1, value as number) });
   }
 
   getSwingAngleCurrentVerticalTiltAngle(): CharacteristicValue {
@@ -1008,7 +1004,7 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
   }
 
   async setSwingAngleTargetVerticalTiltAngle(value: CharacteristicValue) {
-    await this.device.set_swing_angle(SwingAngle.VERTICAL, Math.max(1, value as number));
+    await this.device.queue_attribute({ WIND_SWING_UD_ANGLE: Math.max(1, value as number) });
   }
 
   getSleepMode(): CharacteristicValue {
@@ -1019,9 +1015,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setSleepMode(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ POWER: true, COMFORT_SLEEP_MODE: true });
+      await this.device.queue_attribute({ POWER: true, COMFORT_SLEEP_MODE: true });
     } else {
-      await this.device.set_attribute({ COMFORT_SLEEP_MODE: false });
+      await this.device.queue_attribute({ COMFORT_SLEEP_MODE: false });
     }
   }
 
@@ -1033,9 +1029,9 @@ export default class AirConditionerAccessory extends BaseAccessory<MideaACDevice
 
   async setComfortMode(value: CharacteristicValue) {
     if (value) {
-      await this.device.set_attribute({ POWER: true, COMFORT_MODE: true });
+      await this.device.queue_attribute({ POWER: true, COMFORT_MODE: true });
     } else {
-      await this.device.set_attribute({ COMFORT_MODE: false });
+      await this.device.queue_attribute({ COMFORT_MODE: false });
     }
   }
 }

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -58,6 +58,9 @@ export default abstract class MideaDevice extends EventEmitter {
 
   private pending_attributes: DeviceAttributeBase = {};
   private flush_timer?: ReturnType<typeof setTimeout>;
+  private flush_promise?: Promise<void>;
+  private flush_reject?: (reason: Error) => void;
+  private flush_chain: Promise<void> = Promise.resolve();
   protected readonly COALESCE_WINDOW_MS = 50;
 
   public abstract attributes: DeviceAttributeBase;
@@ -236,14 +239,22 @@ export default abstract class MideaDevice extends EventEmitter {
 
   public queue_attribute(attributes: DeviceAttributeBase) {
     Object.assign(this.pending_attributes, attributes);
-    if (this.flush_timer === undefined) {
-      this.flush_timer = setTimeout(async () => {
+    this.flush_promise ??= new Promise<void>((resolve, reject) => {
+      this.flush_reject = reject;
+      this.flush_timer = setTimeout(() => {
         this.flush_timer = undefined;
+        this.flush_promise = undefined;
+        this.flush_reject = undefined;
+
         const queued_attributes = this.pending_attributes;
         this.pending_attributes = {};
-        await this.set_attribute(queued_attributes);
+
+        const flush = this.flush_chain.then(() => this.set_attribute(queued_attributes));
+        this.flush_chain = flush.catch(() => {});
+        flush.then(resolve, reject);
       }, this.COALESCE_WINDOW_MS);
-    }
+    });
+    return this.flush_promise;
   }
 
   public async refresh_status(wait_response = false, ignore_unsupported = false) {
@@ -420,6 +431,16 @@ export default abstract class MideaDevice extends EventEmitter {
   public close() {
     if (this.is_running) {
       this.is_running = false;
+      if (this.flush_timer !== undefined) {
+        clearTimeout(this.flush_timer);
+        this.flush_timer = undefined;
+        this.flush_promise = undefined;
+
+        this.pending_attributes = {};
+
+        this.flush_reject?.(new Error(`[${this.name}] Device closed before queued attributes were sent`));
+        this.flush_reject = undefined;
+      }
       this.close_socket();
     }
   }

--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -56,6 +56,10 @@ export default abstract class MideaDevice extends EventEmitter {
 
   private promiseSocket: PromiseSocket;
 
+  private pending_attributes: DeviceAttributeBase = {};
+  private flush_timer?: ReturnType<typeof setTimeout>;
+  protected readonly COALESCE_WINDOW_MS = 50;
+
   public abstract attributes: DeviceAttributeBase;
 
   protected abstract build_query(): MessageRequest[];
@@ -228,6 +232,18 @@ export default abstract class MideaDevice extends EventEmitter {
     const data = command.serialize();
     const message = new PacketBuilder(this.id, data).finalize();
     await this.send_message(message);
+  }
+
+  public queue_attribute(attributes: DeviceAttributeBase) {
+    Object.assign(this.pending_attributes, attributes);
+    if (this.flush_timer === undefined) {
+      this.flush_timer = setTimeout(async () => {
+        this.flush_timer = undefined;
+        const queued_attributes = this.pending_attributes;
+        this.pending_attributes = {};
+        await this.set_attribute(queued_attributes);
+      }, this.COALESCE_WINDOW_MS);
+    }
   }
 
   public async refresh_status(wait_response = false, ignore_unsupported = false) {

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -399,7 +399,7 @@ export default class MideaACDevice extends MideaDevice {
               messageToSend.GENERAL.swing_vertical = false;
             }
           } else if (k === 'SWING_HORIZONTAL' || k === 'SWING_VERTICAL') {
-            messageToSend.GENERAL ??= this.make_message_unique_set();
+            messageToSend.GENERAL ??= this.make_message_set();
             messageToSend.GENERAL[k.toLowerCase()] = v;
             this.attributes.WIND_SWING_LR_ANGLE = 0;
             this.attributes.WIND_SWING_UD_ANGLE = 0;

--- a/src/devices/ac/MideaACDevice.ts
+++ b/src/devices/ac/MideaACDevice.ts
@@ -9,7 +9,7 @@
 import type { Logger } from 'homebridge';
 import type { DeviceInfo } from '../../core/MideaConstants.js';
 import MideaDevice, { type DeviceAttributeBase } from '../../core/MideaDevice.js';
-import { ACMode, type Config, type DeviceConfig, SwingAngle } from '../../platformUtils.js';
+import { ACMode, type Config, type DeviceConfig } from '../../platformUtils.js';
 import {
   MessageACResponse,
   MessageCapabilitiesAdditionalQuery,
@@ -391,6 +391,33 @@ export default class MideaACDevice extends MideaDevice {
             const fresh_air = value > 0 ? [true, value] : [false, this.attributes.FRESH_AIR_FAN_SPEED];
             messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
             messageToSend.NEW_PROTOCOL[this.fresh_air_version] = fresh_air;
+          } else if (k === 'WIND_SWING_UD_ANGLE' || k === 'WIND_SWING_LR_ANGLE') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            this.set_swing_angle(k, v as number, messageToSend.NEW_PROTOCOL);
+            if (messageToSend.GENERAL instanceof MessageGeneralSet) {
+              messageToSend.GENERAL.swing_horizontal = false;
+              messageToSend.GENERAL.swing_vertical = false;
+            }
+          } else if (k === 'SWING_HORIZONTAL' || k === 'SWING_VERTICAL') {
+            messageToSend.GENERAL ??= this.make_message_unique_set();
+            messageToSend.GENERAL[k.toLowerCase()] = v;
+            this.attributes.WIND_SWING_LR_ANGLE = 0;
+            this.attributes.WIND_SWING_UD_ANGLE = 0;
+          } else if (k === 'SELF_CLEAN' || k === 'OUT_SILENT' || k === 'RATE_SELECT') {
+            messageToSend.NEW_PROTOCOL ??= new MessageNewProtocolSet(this.device_protocol_version);
+            messageToSend.NEW_PROTOCOL[k.toLowerCase()] = v;
+            messageToSend.NEW_PROTOCOL.prompt_tone = this.attributes.PROMPT_TONE;
+          } else if (k === 'FAN_AUTO') {
+            messageToSend.GENERAL ??= this.make_message_unique_set();
+            this.disable_all_fan_related_modes(messageToSend.GENERAL);
+            if (v) {
+              this.last_fan_speed = this.attributes.FAN_SPEED;
+              messageToSend.GENERAL.fan_speed = AUTO_FAN_SPEED;
+              this.attributes.FAN_SPEED = AUTO_FAN_SPEED;
+            } else {
+              messageToSend.GENERAL.fan_speed = this.last_fan_speed;
+              this.attributes.FAN_SPEED = this.last_fan_speed;
+            }
           } else if (k === 'FAN_SPEED') {
             messageToSend.GENERAL ??= this.make_message_unique_set();
             this.set_fan_speed(v as number, messageToSend.GENERAL);
@@ -442,34 +469,6 @@ export default class MideaACDevice extends MideaDevice {
     this.alternate_switch_display = value;
   }
 
-  async set_target_temperature(target_temperature: number, mode?: number) {
-    this.logger.info(`[${this.name}] Set target temperature to: ${target_temperature}`);
-    const message = this.make_message_unique_set();
-    message.target_temperature = target_temperature;
-    if (mode) {
-      message.mode = mode;
-      message.power = true;
-    }
-    await this.build_send(message);
-    this.attributes.TARGET_TEMPERATURE = target_temperature;
-    if (mode) {
-      this.attributes.MODE = mode;
-      this.attributes.POWER = true;
-    }
-  }
-
-  async set_swing(swing_horizontal: boolean, swing_vertical: boolean) {
-    this.logger.info(`[${this.name}] Set swing horizontal to: ${swing_horizontal}, vertical to: ${swing_vertical}`);
-    const message = this.make_message_set();
-    message.swing_horizontal = swing_horizontal;
-    message.swing_vertical = swing_vertical;
-    await this.build_send(message);
-    this.attributes.SWING_HORIZONTAL = swing_horizontal;
-    this.attributes.SWING_VERTICAL = swing_vertical;
-    this.attributes.WIND_SWING_LR_ANGLE = 0;
-    this.attributes.WIND_SWING_UD_ANGLE = 0;
-  }
-
   private disable_all_fan_related_modes(message: MessageGeneralSet | MessageSubProtocolSet) {
     // Check if any fan-related mode is currently active
     const anyModeActive = this.FAN_RELATED_MODES.some((mode) => this.attributes[mode]);
@@ -492,31 +491,6 @@ export default class MideaACDevice extends MideaDevice {
     this.attributes.ECO_MODE = false;
     this.attributes.FROST_PROTECT = false;
     this.attributes.COMFORT_MODE = false;
-  }
-
-  async set_fan_auto(fan_auto: boolean) {
-    const previousAttributes = { ...this.attributes };
-    const previousLastFanSpeed = this.last_fan_speed;
-    this.logger.info(`[${this.name}] Set fan auto to: ${fan_auto}`);
-    const message = this.make_message_unique_set();
-
-    this.disable_all_fan_related_modes(message);
-
-    if (fan_auto) {
-      // Save last fan speed before setting to auto
-      this.last_fan_speed = this.attributes.FAN_SPEED;
-    }
-    const fan_speed = fan_auto ? AUTO_FAN_SPEED : this.last_fan_speed;
-    message.fan_speed = fan_speed;
-    this.attributes.FAN_SPEED = fan_speed;
-    this.attributes.FAN_AUTO = fan_auto;
-    try {
-      await this.build_send(message);
-    } catch (err) {
-      this.attributes = previousAttributes;
-      this.last_fan_speed = previousLastFanSpeed;
-      throw err;
-    }
   }
 
   set_fan_speed(fan_speed: number, message: MessageGeneralSet | MessageSubProtocolSet) {
@@ -568,53 +542,16 @@ export default class MideaACDevice extends MideaDevice {
     }
   }
 
-  async set_swing_angle(swing_direction: SwingAngle, swing_angle: number) {
-    this.logger.info(`[${this.name}] Set swing ${swing_direction} angle to: ${swing_angle}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    switch (swing_direction) {
-      case SwingAngle.HORIZONTAL:
-        message.wind_swing_lr_angle = swing_angle;
-        break;
-      case SwingAngle.VERTICAL:
-        message.wind_swing_ud_angle = swing_angle;
-        break;
+  set_swing_angle(swing_direction: 'WIND_SWING_UD_ANGLE' | 'WIND_SWING_LR_ANGLE', swing_angle: number, message: MessageNewProtocolSet) {
+    this.logger.info(`[${this.name}] Set ${swing_direction} to: ${swing_angle}`);
+    if (swing_direction === 'WIND_SWING_UD_ANGLE') {
+      message.wind_swing_ud_angle = swing_angle;
+    } else {
+      message.wind_swing_lr_angle = swing_angle;
     }
     message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
     this.attributes.SWING_HORIZONTAL = false;
     this.attributes.SWING_VERTICAL = false;
-    if (swing_direction === SwingAngle.HORIZONTAL) {
-      this.attributes.WIND_SWING_LR_ANGLE = swing_angle;
-    } else {
-      this.attributes.WIND_SWING_UD_ANGLE = swing_angle;
-    }
-  }
-
-  async set_self_clean(self_clean: boolean) {
-    this.logger.info(`[${this.name}] Set self clean to: ${self_clean}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    message.self_clean = self_clean;
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
-    this.attributes.SELF_CLEAN = self_clean;
-  }
-
-  async set_rate_select(rate_select: number) {
-    this.logger.info(`[${this.name}] Set rate select to: ${rate_select}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    message.rate_select = rate_select;
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
-    this.attributes.RATE_SELECT = rate_select;
-  }
-
-  async set_out_silent(out_silent: boolean) {
-    this.logger.info(`[${this.name}] Set out silent to: ${out_silent}`);
-    const message = new MessageNewProtocolSet(this.device_protocol_version);
-    message.out_silent = out_silent;
-    message.prompt_tone = this.attributes.PROMPT_TONE;
-    await this.build_send(message);
-    this.attributes.OUT_SILENT = out_silent;
   }
 
   protected set_subtype(): void {


### PR DESCRIPTION
## What does this PR do?

When HomeKit scenes/automations set multiple attributes at once, each onSet handler is being stacked and calling `set_attribute` (and subsequently `build_message`) separately and asynchronously. This creates overlapping messages in such quick succession that some attributes/messages are being dropped by the AC unit.

Instead, I created the `queue_attribute` method that will collect all attribute updates during a 50ms window (50ms is enough time for all the attributes to be set by the HomeKit scene/automation), coalesce and flush them to the device as a single update. Each `queue_attribute` call will await success/failure so HomeKit can reflect the attribute status.

I updated `set_swing_angle` method to match the pattern used in `set_fan_speed` so that all swing angle attributes could be handled in the queue_attribute coalesce.

Replaced the `set_target_temperature`, `set_swing`, `set_fan_auto`, `set_self_clean`, `set_out_silent`, and `set_rate_select` methods in favor of handling the logic within the `set_attribute` method on the device itself. I was able to test these on my DUO, but I don't have any other Midea devices to make sure that these changes work on all the other models.

Since the `queue_attribute` method is in the MideaDevice base, other devices can adopt the new coalesce feature as needed.

## How was it tested?

Tested on a Midea DUO portable AC unit. I have HomeKit automations set several times throughout the day with multiple characteristic included (target_temperature, power, mode, wind_swing_ud_angle, and screen_display). With these changes, all characteristics are being applied reliably via automation.

## AI assistance disclosure

Assisted-by: Claude Code for initial discovery and diagnosis

---

**Checklist**

- [x] I read the [contribution guidelines](/CONTRIBUTING.md)
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](/CONTRIBUTING.md#ai-policy)
- [x] I tested this on real hardware (required for device-specific changes)
- [x] I ran `npm run lint` and `npm run fmt:check` and there are no warnings
