### PR TITLE
fix(core): keep reconnects in listener

### DIFF
--- a/src/core/MideaDevice.ts
+++ b/src/core/MideaDevice.ts
@@ -197,22 +197,18 @@ export default abstract class MideaDevice extends EventEmitter {
     }
   }
 
-  private async send_message_v2(data: Buffer, retries = 3, force_reinit = false) {
-    if (retries === 0) {
-      throw new Error(`[${this.name} | send_message] Error when sending data to device.`);
-    }
-    if (force_reinit || !this.promiseSocket || this.promiseSocket.destroyed) {
-      this.promiseSocket = new PromiseSocket(this.logger, this.logRecoverableErrors);
-      let connected = await this.connect(false);
-      while (!connected) {
-        connected = await this.connect(false);
-      }
+  private async send_message_v2(data: Buffer) {
+    if (this.promiseSocket.destroyed) {
+      throw new Error(`[${this.name} | send_message] Socket is not connected.`);
     }
     try {
       await this.promiseSocket.write(data);
-    } catch {
-      this.logger.debug(`[${this.name}] Error when sending data to device, retrying...`);
-      await this.send_message_v2(data, retries - 1, true);
+    } catch (err) {
+      // The network listener owns reconnects.  Retrying here can reconnect a
+      // socket that the listener is concurrently reading, then strand it when
+      // the replacement handshake fails.
+      this.close_socket();
+      throw err;
     }
   }
 
@@ -477,6 +473,9 @@ export default abstract class MideaDevice extends EventEmitter {
           } else if (now - previous_heartbeat >= this.heartbeat_interval) {
             await this.send_heartbeat();
             previous_heartbeat = now;
+          }
+          if (this.promiseSocket.destroyed) {
+            continue;
           }
           // We wait up to one second for a message, in effect we cause the while loop
           // we are in to itterate once a second... allowing us to check for heartbeat

--- a/src/core/MideaUtils.ts
+++ b/src/core/MideaUtils.ts
@@ -159,6 +159,9 @@ export class PromiseSocket {
   }
 
   public async read() {
+    if (this.destroyed) {
+      return Buffer.alloc(0);
+    }
     return new Promise<Buffer>((resolve, reject) => {
       let buf = Buffer.alloc(0);
 

--- a/test/device-errors.test.js
+++ b/test/device-errors.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DeviceType, ProtocolVersion } from '../src/core/MideaConstants.ts';
 import MideaACDevice from '../src/devices/ac/MideaACDevice.ts';
+import { PromiseSocket } from '../src/core/MideaUtils.ts';
 import { MideaPlatform } from '../src/platform.ts';
 import { defaultConfig, defaultDeviceConfig } from '../src/platformUtils.ts';
 
@@ -12,7 +13,7 @@ const logger = {
   warn() {},
 };
 
-function createDevice() {
+function createDevice(version = ProtocolVersion.V3) {
   return new MideaACDevice(
     logger,
     {
@@ -23,7 +24,7 @@ function createDevice() {
       sn: 'test',
       name: 'Test AC',
       type: DeviceType.AIR_CONDITIONER,
-      version: ProtocolVersion.V3,
+      version,
     },
     structuredClone(defaultConfig),
     structuredClone(defaultDeviceConfig),
@@ -34,6 +35,58 @@ test('rejects V3 commands while unauthenticated', async () => {
   const device = createDevice();
 
   await assert.rejects(device.send_message(Buffer.alloc(0)), /not authenticated/);
+});
+
+test('does not reconnect synchronously when a socket is destroyed', async () => {
+  const device = createDevice(ProtocolVersion.V2);
+  let connectCalls = 0;
+  device.connect = async () => {
+    connectCalls++;
+    throw new Error('unexpected reconnect');
+  };
+  device.promiseSocket = { destroyed: true };
+
+  await assert.rejects(device.send_message(Buffer.alloc(0)), /Socket is not connected/);
+  assert.equal(connectCalls, 0);
+});
+
+test('closes the socket after a send failure and leaves reconnecting to the listener', async () => {
+  const device = createDevice(ProtocolVersion.V2);
+  let connectCalls = 0;
+  const socket = {
+    destroyed: false,
+    async write() {
+      throw new Error('write failed');
+    },
+    destroy() {
+      this.destroyed = true;
+    },
+  };
+  device.connect = async () => {
+    connectCalls++;
+    throw new Error('unexpected reconnect');
+  };
+  device.promiseSocket = socket;
+
+  await assert.rejects(device.send_message(Buffer.alloc(0)), /write failed/);
+  assert.equal(socket.destroyed, true);
+  assert.equal(connectCalls, 0);
+});
+
+test('returns immediately when reading an already destroyed socket', async () => {
+  const socket = new PromiseSocket(logger, false);
+  socket.destroyed = true;
+  let timeout;
+
+  const result = await Promise.race([
+    socket.read(),
+    new Promise((resolve) => {
+      timeout = setTimeout(() => resolve(undefined), 20);
+    }),
+  ]);
+  clearTimeout(timeout);
+
+  assert.deepEqual(result, Buffer.alloc(0));
 });
 
 test('restores AC attributes when a command fails', async () => {


### PR DESCRIPTION
## What does this PR do?

Keeps reconnect ownership in the network listener after a socket reset. A failed send now closes the socket and returns the current request error, allowing the listener's existing backoff loop to authenticate a fresh connection without competing reconnect attempts.

## How was it tested?

- `npm test`
- `npm run lint`
- `npm run fmt:check`
- `npm run build`
- Verified activation on a local V3 device set after a child-bridge restart; all configured sessions authenticated successfully.

Related to #192.

## AI assistance disclosure

Assisted-by: Codex. The implementation and test coverage were reviewed before submission.

---

- [x] I read the contribution guidelines.
- [x] If this PR used AI assistance, I followed the AI Contribution Policy.
- [x] I tested this on real hardware.
- [x] I ran `npm run lint` and `npm run fmt:check` and there are no warnings.
